### PR TITLE
Initial setup.py, .travis.yml & resource loading via pkg_resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ python:
     - "3.7"
     - "3.8"
 
+deploy:
+    provider: releases
+    api_key: "GITHUB OAUTH TOKEN"
+    file_glob: true
+    file: dist/*.whl
+    skip_cleanup: true
+    draft: true
+    on:
+        tags: true
+
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
     - "3.6"
-    - "3.7"
-    - "3.8"
 
 deploy:
     provider: releases
@@ -25,7 +23,13 @@ matrix:
       compiler: clang
 
 install:
+  # ensure recent versions of setuptools
   - python -m pip install -U setuptools wheel pip
 
 script:
+  # test if we can still build
   - python setup.py bdist_wheel
+  # install in development-mode
+  - python setup.py develop
+  # tests
+  - python -c 'import wgpu'  # stub

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+matrix:
+  include:
+    - os: linux
+      rust: nightly
+      compiler: gcc
+      dist: xenial
+      language: rust
+      sudo: false
+    - os: windows
+      rust: nightly
+      language: rust
+    - env: MACOSX_DEPLOYMENT_TARGET=10.9
+      os: osx
+      rust: nightly
+      osx_image: xcode9.4
+      compiler: clang
+      language: rust
+addons:
+  apt:
+    packages:
+    - cmake
+    - libglfw3-dev
+  homebrew:
+    update: true
+    packages:
+    - cmake
+    - glfw3
+
+before_install:
+- if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; fi
+
+script:
+  - git clone https://github.com/gfx-rs/wgpu.git wgpu-native
+  - cd wgpu-native
+  - git checkout v0.4
+  - cargo test
+  # TODO: enable GL backend
+  - (cd wgpu-core && cargo check --all-features)
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (cd wgpu-native && cargo check --features vulkan-portability); fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then cargo check --release; fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo +nightly install cbindgen; fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then
+      wget -nc -O glfw.zip https://github.com/glfw/glfw/archive/3.3.zip &&
+      7z x glfw.zip -oglfw &&
+      cd glfw/glfw-3.3 &&
+      export GLFW3_INCLUDE_DIR=`pwd`/include &&
+      export GLFW3_INSTALL_DIR=`pwd`/install &&
+      cmake . -DCMAKE_INSTALL_PREFIX=$GLFW3_INSTALL_DIR -DCMAKE_GENERATOR_PLATFORM=x64 &&
+      cmake --build . --target install &&
+      cd ../.. &&
+      export CMAKE_PREFIX_PATH=$GLFW3_INSTALL_DIR &&
+      make example-compute example-triangle VERBOSE=1;
+    fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME != "windows" ]]; then make VERBOSE=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ script:
   - cd wgpu-native
   - git checkout v0.4
   # TODO: enable GL backend
-  - (cd wgpu-core && cargo check --all-features)
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (cd wgpu-native && cargo check --features vulkan-portability); fi
+  - (cd wgpu-native && cargo check --all-features)
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (cd wgpu-native && cargo check --features gfx-backend-vulkan); fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then cargo check --release; fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo +nightly install cbindgen; fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,21 @@
+language: python
+python:
+    - "3.6"
+    - "3.7"
+    - "3.8"
+
 matrix:
   include:
     - os: linux
-      rust: nightly
-      compiler: gcc
       dist: xenial
-      language: rust
     - os: windows
-      rust: nightly
-      language: rust
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
-      rust: nightly
       osx_image: xcode9.4
       compiler: clang
-      language: rust
-addons:
-  apt:
-    packages:
-    - cmake
-    - libglfw3-dev
-  homebrew:
-    update: true
-    packages:
-    - cmake
-    - glfw3
 
-before_install:
-- if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; fi
+install:
+  - python -m pip install -U setuptools wheel pip
 
 script:
-  - git clone https://github.com/gfx-rs/wgpu.git wgpu-native
-  - cd wgpu-native
-  - git checkout v0.4
-  # TODO: enable GL backend
-  - (cd wgpu-native && cargo check --all-features)
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (cd wgpu-native && cargo check --features gfx-backend-vulkan); fi
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then cargo check --release; fi
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo +nightly install cbindgen; fi
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME == "windows" ]]; then
-      wget -nc -O glfw.zip https://github.com/glfw/glfw/archive/3.3.zip &&
-      7z x glfw.zip -oglfw &&
-      cd glfw/glfw-3.3 &&
-      export GLFW3_INCLUDE_DIR=`pwd`/include &&
-      export GLFW3_INSTALL_DIR=`pwd`/install &&
-      cmake . -DCMAKE_INSTALL_PREFIX=$GLFW3_INSTALL_DIR -DCMAKE_GENERATOR_PLATFORM=x64 &&
-      cmake --build . --target install &&
-      cd ../.. &&
-      export CMAKE_PREFIX_PATH=$GLFW3_INSTALL_DIR &&
-      make example-compute example-triangle VERBOSE=1;
-    fi
-  - make lib-native ffi/wgpu.h VERBOSE=1;
+  - python setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
       compiler: gcc
       dist: xenial
       language: rust
-      sudo: false
     - os: windows
       rust: nightly
       language: rust
@@ -33,7 +32,6 @@ script:
   - git clone https://github.com/gfx-rs/wgpu.git wgpu-native
   - cd wgpu-native
   - git checkout v0.4
-  - cargo test
   # TODO: enable GL backend
   - (cd wgpu-core && cargo check --all-features)
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then (cd wgpu-native && cargo check --features vulkan-portability); fi
@@ -51,4 +49,4 @@ script:
       export CMAKE_PREFIX_PATH=$GLFW3_INSTALL_DIR &&
       make example-compute example-triangle VERBOSE=1;
     fi
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]] && [[ $TRAVIS_OS_NAME != "windows" ]]; then make VERBOSE=1; fi
+  - make lib-native ffi/wgpu.h VERBOSE=1;

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+import re
+
+from setuptools import find_packages, setup
+
+
+NAME = "wgpu"
+
+with open(f"{NAME}/__version__.py") as fh:
+    VERSION = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
+
+
+# the binary components of this library are pre-built
+# so setuptools can't tell our wheel should have a platform tag
+# therefore we use a custom bdist_wheel command to force it
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+class bdist_wheel(_bdist_wheel):
+    def finalize_options(self):
+        _bdist_wheel.finalize_options(self)
+        self.root_is_pure = False
+
+
+setup(
+    name=NAME,
+    version=VERSION,
+    packages=find_packages(exclude=["tests", "tests.*", "examples", "examples.*"]),
+    package_data={
+        f'{NAME}.resources': ['*.dll', '*.so', '*.dylib', '*.h', '*.idl'],
+    },
+    python_requires=">=3.6.0",
+    license=open("LICENSE").read(),
+    description=open("README.md").readlines()[2],
+    long_description=open("README.md").read(),
+    long_description_content_type='text/markdown',
+    author="Almar Klein",
+    author_email="almarklein@gmail.com",
+    url="https://github.com/almarklein/wgpu-py",
+    cmdclass={'bdist_wheel': bdist_wheel},
+)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 NAME = "wgpu"
 
-with open(f"{NAME}/__version__.py") as fh:
+with open(f"{NAME}/__init__.py") as fh:
     VERSION = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
 
 

--- a/wgpu/rs.py
+++ b/wgpu/rs.py
@@ -15,7 +15,7 @@ from cffi import FFI
 
 from . import classes
 from . import _register_backend
-from .utils import get_resource_dir
+from .utils import get_resource_filename
 from ._mappings import cstructfield2enum, enummap
 
 
@@ -23,7 +23,7 @@ os.environ["RUST_BACKTRACE"] = "0"  # Set to 1 for more trace info
 
 # Read header file and strip some stuff that cffi would stumble on
 lines = []
-with open(os.path.join(get_resource_dir(), "wgpu.h")) as f:
+with open(get_resource_filename("wgpu.h")) as f:
     for line in f.readlines():
         if not line.startswith(
             (
@@ -44,7 +44,7 @@ ffi.cdef("".join(lines))
 ffi.set_source("wgpu.h", None)
 
 # Load the dynamic library
-_lib = ffi.dlopen(os.path.join(get_resource_dir(), "wgpu_native-debug.dll"))
+_lib = ffi.dlopen(get_resource_filename("wgpu_native-debug.dll"))
 
 
 def new_struct(ctype, **kwargs):

--- a/wgpu/utils.py
+++ b/wgpu/utils.py
@@ -4,13 +4,13 @@ Utility functions.
 
 import os
 import inspect
+from pkg_resources import resource_filename
 
 from . import classes as m_classes, flags as m_flags, enums as m_enums
 
 
-def get_resource_dir():
-    # todo: use setuptools package data thingy
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources")
+def get_resource_filename(name):
+    return resource_filename("wgpu.resources", name)
 
 
 def help(*searches, dev=False):
@@ -37,10 +37,10 @@ def help(*searches, dev=False):
     if dev:
         from ._parsers import IdlParser, HParser
 
-        filename = os.path.join(get_resource_dir(), "webgpu.idl")
+        filename = os.path.join(get_resource_filename("webgpu.idl"))
         idl_parser = IdlParser(open(filename, "rb").read().decode())
         idl_parser.parse()
-        filename = os.path.join(get_resource_dir(), "wgpu.h")
+        filename = os.path.join(get_resource_filename("wgpu.h"))
         h_parser = HParser(open(filename, "rb").read().decode())
         h_parser.parse()
 


### PR DESCRIPTION
This PR brings:

- Creating platform wheels with `python setup.py bdist_wheel`
- Running builds and tests on Travis CI
- Loading files from the `resources` subdir in development, installed and frozen states (via `pkg_resources.resource_filename`)

You will need to do two things when merging this PR:

* enable Travis builds for your personal repo
* add a GitHub OAuth token securely with Travis encrypted variables to `.travis.yml` (which currently holds a stub value) or build environment variables (see https://docs.travis-ci.com/user/deployment-v2/providers/releases/ "Securing secrets" "Authenticating with an OAuth token")

Also note:

* I don't think `resource_filename` will work without installing `wgpu` in development mode using `python setup.py develop`, so don't forget about that.

Caution:

After thinking about it for a while, I realize I'd like to try setting up Azure Pipelines as well, Travis seems to be too limited for our needs here (particularly in supporting Windows builds).