### PR TITLE
Wheels are no longer bound to CPython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# VSCode project settings
+.vscode
+
 # Rope project settings
 .ropeproject
 
@@ -107,3 +110,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Pipenv (for now, dev-requirements.txt is sufficient)
+Pipfile
+Pipfile.lock

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import re
 
 from setuptools import find_packages, setup
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+from wheel.pep425tags import get_platform
 
 
 NAME = "wgpu"
@@ -10,16 +12,10 @@ with open(f"{NAME}/__init__.py") as fh:
     VERSION = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
 
 
-# the binary components of this library are pre-built
-# so setuptools can't tell our wheel should have a platform tag
-# therefore we use a custom bdist_wheel command to force it
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-
-
 class bdist_wheel(_bdist_wheel):
     def finalize_options(self):
+        self.plat_name = get_platform()  # force a platform tag
         _bdist_wheel.finalize_options(self)
-        self.root_is_pure = False
 
 
 setup(
@@ -27,7 +23,6 @@ setup(
     version=VERSION,
     packages=find_packages(exclude=["tests", "tests.*", "examples", "examples.*"]),
     package_data={f"{NAME}.resources": ["*.dll", "*.so", "*.dylib", "*.h", "*.idl"]},
-    python_requires=">=3.6.0",
     license=open("LICENSE").read(),
     description=SUMMARY,
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     version=VERSION,
     packages=find_packages(exclude=["tests", "tests.*", "examples", "examples.*"]),
     package_data={f"{NAME}.resources": ["*.dll", "*.so", "*.dylib", "*.h", "*.idl"]},
+    python_requires=">=3.6.0",
     license=open("LICENSE").read(),
     description=SUMMARY,
     long_description=open("README.md").read(),


### PR DESCRIPTION
Fixes #6 

Wheels are now bound to any version of Python 3 and the platform on which the wheel is built.