### PR TITLE
Simplify initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ The full API is accessable via the main namespace:
 import wgpu
 ```
 
-But to use it, you need to select a backend first. You do this by importing it.
-There is currently only one backend:
+But to use it, you need to initialize the library first. You can provide
+configuration overloads here, such as the choice of backend (default backend is
+Rust, ie: `backend='rs'`):
+
 ```py
-import wgpu.backend.rs
+wgpu.init()
 ```
 
 To give an idea of what this API looks like, here's the API code from the triangle example:
@@ -67,6 +69,7 @@ To give an idea of what this API looks like, here's the API code from the triang
 # ... code to create shaders and GUI are omitted for brevity
 
 import wgpu
+wgpu.init()
 
 async def main(canvas):
 

--- a/examples/triangle_glfw.py
+++ b/examples/triangle_glfw.py
@@ -126,7 +126,7 @@ import glfw
 from wgpu.gui.glfw import WgpuCanvas  # WgpuCanvas wraps a glfw window
 import wgpu
 
-wgpu.init("rs")
+wgpu.init()
 
 
 glfw.init()

--- a/examples/triangle_glfw.py
+++ b/examples/triangle_glfw.py
@@ -124,7 +124,8 @@ import asyncio
 
 import glfw
 from wgpu.gui.glfw import WgpuCanvas  # WgpuCanvas wraps a glfw window
-import wgpu.backend.rs  # Select Rust backend
+import wgpu
+wgpu.init('rs')
 
 
 glfw.init()

--- a/examples/triangle_glfw.py
+++ b/examples/triangle_glfw.py
@@ -125,7 +125,8 @@ import asyncio
 import glfw
 from wgpu.gui.glfw import WgpuCanvas  # WgpuCanvas wraps a glfw window
 import wgpu
-wgpu.init('rs')
+
+wgpu.init("rs")
 
 
 glfw.init()

--- a/examples/triangle_js.py
+++ b/examples/triangle_js.py
@@ -127,7 +127,7 @@ from flexx import flx
 from wgpu.gui.flexx import WgpuCanvas  # WgpuCanvas is a flx.Canvas subclass
 import wgpu
 
-wgpu.init("js")
+wgpu.init(backend="js")
 
 
 class Example(flx.Widget):

--- a/examples/triangle_js.py
+++ b/examples/triangle_js.py
@@ -126,7 +126,8 @@ async def main(canvas):
 from flexx import flx
 from wgpu.gui.flexx import WgpuCanvas  # WgpuCanvas is a flx.Canvas subclass
 import wgpu
-wgpu.init('js')
+
+wgpu.init("js")
 
 
 class Example(flx.Widget):

--- a/examples/triangle_js.py
+++ b/examples/triangle_js.py
@@ -125,7 +125,8 @@ async def main(canvas):
 
 from flexx import flx
 from wgpu.gui.flexx import WgpuCanvas  # WgpuCanvas is a flx.Canvas subclass
-import wgpu.backend.js  # Select JS backend
+import wgpu
+wgpu.init('js')
 
 
 class Example(flx.Widget):

--- a/examples/triangle_qt.py
+++ b/examples/triangle_qt.py
@@ -124,7 +124,8 @@ import asyncio
 
 from PyQt5 import QtWidgets  # Use either PyQt5 or Pyside2
 from wgpu.gui.qt import WgpuCanvas  # GPUCanvas is a QWidget subclass
-import wgpu.backend.rs  # Select Rust backend
+import wgpu
+wgpu.init('rs')
 
 
 app = QtWidgets.QApplication([])

--- a/examples/triangle_qt.py
+++ b/examples/triangle_qt.py
@@ -125,7 +125,8 @@ import asyncio
 from PyQt5 import QtWidgets  # Use either PyQt5 or Pyside2
 from wgpu.gui.qt import WgpuCanvas  # GPUCanvas is a QWidget subclass
 import wgpu
-wgpu.init('rs')
+
+wgpu.init("rs")
 
 
 app = QtWidgets.QApplication([])

--- a/examples/triangle_qt.py
+++ b/examples/triangle_qt.py
@@ -126,7 +126,7 @@ from PyQt5 import QtWidgets  # Use either PyQt5 or Pyside2
 from wgpu.gui.qt import WgpuCanvas  # GPUCanvas is a QWidget subclass
 import wgpu
 
-wgpu.init("rs")
+wgpu.init()
 
 
 app = QtWidgets.QApplication([])

--- a/wgpu/__init__.py
+++ b/wgpu/__init__.py
@@ -26,3 +26,11 @@ def requestAdapterSync(powerPreference: "enum PowerPreference"):
 
     loop = asyncio.get_event_loop()
     return loop.run_until_complete(requestAdapter(powerPreference))
+
+
+def init(backend="rs"):
+    """ Initialize wgpu by loading a backend
+    """
+    import importlib
+
+    return importlib.import_module(".".join(__name__, "backend", backend))

--- a/wgpu/backend/__init__.py
+++ b/wgpu/backend/__init__.py
@@ -1,4 +1,6 @@
 """
 The backend implementations of the wgpu API.
 You need to select one by importing it, e.g. ``import wgpu.backend.rs``.
+The root module provides a convenience function that does this for
+you: `wgpu.init(backend='rs')`.
 """

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -20,9 +20,6 @@ from ..utils import get_resource_filename
 from .._mappings import cstructfield2enum, enummap
 
 
-os.environ["RUST_BACKTRACE"] = "0"  # Set to 1 for more trace info
-
-
 def _get_wgpu_h():
     # Read header file and strip some stuff that cffi would stumble on
     lines = []

--- a/wgpu/classes.py
+++ b/wgpu/classes.py
@@ -9,13 +9,13 @@ in backend modules.
 async def requestAdapter(*, powerPreference: "GPUPowerPreference"):
     """ Request an Adapter, the object that represents the implementation of WGPU.
     Before requesting an adapter, a wgpu backend should be selected. At the moment
-    there is only one backend. Use ``import wgpu.rs`` to select it.
+    there is only one backend. Use ``wgpu.init()`` to select it.
 
     Params:
         powerPreference(enum): "high-performance" or "low-power"
     """
     raise RuntimeError(
-        "Select a backend (by importing wgpu.rs) before requesting an adapter!"
+        "Select a WGPU backend by calling wgpu.init() before requesting an adapter!"
     )
 
 

--- a/wgpu/gui/flexx.py
+++ b/wgpu/gui/flexx.py
@@ -7,7 +7,7 @@ from .base import BaseCanvas
 
 
 class WgpuCanvas(flx.CanvasWidget):
-    """ Flexx widget to be used with the wgpu.backed.js backend. Provides a
+    """ Flexx widget to be used with the wgpu.backend.js backend. Provides a
     canvas to render to.
     """
 


### PR DESCRIPTION
I felt like the backend import mechanism is a good fit for our needs _internally_, but harder than it needs to be for _users_. So I left the import mechanism intact, but provided an `init` function on the root module for users. Advantages:

* Users can simply `import wgpu` and call `wgpu.init()` to get started right away, without needing to make a choice of backend (Rust is the default). I think this will be just fine for the majority of users.
* Users can still pick a specific backend by providing the `backend` kwarg to `init`. Example: `wgpu.init(backend='js')`

(I also removed `os.environ["RUST_BACKTRACE"] = "0"` since that is something both developers and users should be able to set on their environment, rather than in code.)