### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ To get an idea of what this API looks like have a look at [triangle.py](https://
 
 * We have a few working examples!
 * This currently only works on Windows.
-* We don't yet package the wgpu lib; you have to bring it along yourself for now.
 * We have not fully implemented the API yet.
 * The API may change. We're still figuring out what works best.
 * The API may change more. Until WebGPU settles as a standard, its specification
@@ -39,9 +38,8 @@ pip install wgpu
 pip install spirv  # optional - our examples use this to define shaders
 ```
 
-This library will eventually include the required Rust library, but for
-now, you have to bring it yourself. Tell where it is by setting the
-environment variable `WGPU_LIB_PATH`.
+The library ships with Rust binaries for Windows, MacOS and Linux. If you want to use
+a custom build instead, you can set the environment variable `WGPU_LIB_PATH`.
 
 
 ## Usage
@@ -81,9 +79,9 @@ This code is distributed under the 2-clause BSD license.
 
 * Clone the repo.
 * Install devtools using `pip install -r dev-requirements.txt` (you can replace `pip` with `pipenv` to install to a virtualenv).
-* Install wgpu-py in editable mode by running `python setup.py develop`, or simply add the root dir to your `PYTHONPATH`.
+* Install wgpu-py in editable mode by running `python setup.py develop`, this will also install our only runtime dependency `cffi`
 * Run `python download-wgpu-native.py` to download the upstream wgpu-native binaries.
-  * Or alternatively point the `WGPU_LIB_PATH` environment variable to the dynamic library created by `wgpu-native`.
+  * Or alternatively point the `WGPU_LIB_PATH` environment variable to a custom build.
 * Use `black .` to apply autoformatting.
 * Use `flake8 .` to check for flake errors.
 * Use `pytest .` to run the tests.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
       script: |
         set -ex
         python -m pip install -U pip
-        pip install -r dev-requirements.txt
+        pip install -U -r dev-requirements.txt
   - task: Bash@3
     displayName: Restore WGPU native binary
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        python -m pip install -U pip setuptools wheel
+        python -m pip install -U pip
         pip install -r dev-requirements.txt
   - task: Bash@3
     displayName: Restore WGPU native binary

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,6 @@ black
 pytest
 flake8
 requests
+setuptools
+wheel
+twine

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -14,13 +14,13 @@ Similar example in other languages / API's:
 """
 
 import wgpu
-from spirv import python2spirv, vec2, vec3, vec4, i32
+from python_shader import python2shader , vec2, vec3, vec4, i32
 
 
 # %% Shaders
 
 
-@python2spirv
+@python2shader
 def vertex_shader(input, output):
     input.define("index", "VertexId", i32)
     output.define("pos", "Position", vec4)
@@ -33,7 +33,7 @@ def vertex_shader(input, output):
     output.color = vec3(p, 0.5)
 
 
-@python2spirv
+@python2shader
 def fragment_shader(input, output):
     input.define("color", 0, vec3)
     output.define("color", 0, vec4)

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -14,7 +14,7 @@ Similar example in other languages / API's:
 """
 
 import wgpu
-from python_shader import python2shader , vec2, vec3, vec4, i32
+from python_shader import python2shader, vec2, vec3, vec4, i32
 
 
 # %% Shaders

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,18 @@ elif sys.platform.startswith("darwin"):
     resources_globs.append("*.dylib")
 
 
+runtime_deps = [
+    "cffi",
+]
+
+
 setup(
     name=NAME,
     version=VERSION,
     packages=find_packages(exclude=["tests", "tests.*", "examples", "examples.*"]),
     package_data={f"{NAME}.resources": resources_globs},
     python_requires=">=3.6.0",
+    install_requires=runtime_deps,
     license=open("LICENSE").read(),
     description=SUMMARY,
     long_description=open("README.md").read(),

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,15 +1,15 @@
-// /* This Source Code Form is subject to the terms of the Mozilla Public
-//  * License, v. 2.0. If a copy of the MPL was not distributed with this
-//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// /* Generated with cbindgen:0.11.1 */
+/* Generated with cbindgen:0.11.1 */
 
-// /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
-//  * To generate this file:
-//  *   1. Get the latest cbindgen using `cargo install --force cbindgen`
-//  *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
-//  *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
-//  */
+/* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
+ * To generate this file:
+ *   1. Get the latest cbindgen using `cargo install --force cbindgen`
+ *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
+ *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
+ */
 
 #define WGPU_LOCAL
 

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,15 +1,15 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// /* This Source Code Form is subject to the terms of the Mozilla Public
+//  * License, v. 2.0. If a copy of the MPL was not distributed with this
+//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Generated with cbindgen:0.11.1 */
+// /* Generated with cbindgen:0.11.1 */
 
-/* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
- * To generate this file:
- *   1. Get the latest cbindgen using `cargo install --force cbindgen`
- *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
- *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
- */
+// /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
+//  * To generate this file:
+//  *   1. Get the latest cbindgen using `cargo install --force cbindgen`
+//  *      a. Alternatively, you can clone `https://github.com/eqrion/cbindgen` and use a tagged release
+//  *   2. Run `rustup run nightly cbindgen toolkit/library/rust/ --lockfile Cargo.lock --crate wgpu-remote -o dom/webgpu/ffi/wgpu_ffi_generated.h`
+//  */
 
 #define WGPU_LOCAL
 


### PR DESCRIPTION
These are all the fixes I had to apply while trying to run the Qt triangle example on Linux, python 3.6.

This PR can be merged, though currently the examples crash on the python-shader compilation, see related PR https://github.com/almarklein/python-shader/pull/9