### PR TITLE
Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To get an idea of what this API looks like have a look at [triangle.py](https://
 *This is experimental, work in progress, you probably don't want to use this just yet!*
 
 * We have a few working examples!
-* These *should* work on all platforms but this is currently only tested on Windows (see #28 and #29), so they probably don't :)
+* Support for Windows and Linux. Support for OSX is underway.
 * We have not fully implemented the API yet.
 * The API may change. We're still figuring out what works best.
 * The API may change more. Until WebGPU settles as a standard, its specification
@@ -40,6 +40,22 @@ pip install python-shader  # optional - our examples use this to define shaders
 
 The library ships with Rust binaries for Windows, MacOS and Linux. If you want to use
 a custom build instead, you can set the environment variable `WGPU_LIB_PATH`.
+
+
+## Platform requirements
+
+Under the hood, `wgpu` runs on Vulkan or Metal, and eventually also DX12 or OpenGL.
+
+On Windows 10, things should just work. On older Windows versions you may need
+to install the Vulkan drivers (or wait for the DX12 backend to become more mature).
+
+On Linux, it's advisable to install the proprietary drivers of your GPU
+(if you have a dedicated GPU). You may need to `apt install mesa-vulkan-drivers`.
+Note that on Linux, the `tk` canvas does not work. Wayland currently only
+works with the GLFW canvas (and is unstable).
+
+On OS X you need at least OSX 10.13 (High Sierra) to have Vulkan support.
+At the moment, we've not implemented drawing to a window yet (see #29).
 
 
 ## Usage

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -100,7 +100,17 @@ def get_surface_id_from_canvas(canvas):
         return _lib.wgpu_create_surface_from_windows_hwnd(hinstance, hwnd)
     elif sys.platform.startswith("darwin"):
         # wgpu_create_surface_from_metal_layer(void *layer)
-        # todo: untested; might well be wrong
+        # todo: OSX support
+        # This is what the triangle example from wgpu-native does:
+        # #if WGPU_TARGET == WGPU_TARGET_MACOS
+        #     {
+        #         id metal_layer = NULL;
+        #         NSWindow *ns_window = glfwGetCocoaWindow(window);
+        #         [ns_window.contentView setWantsLayer:YES];
+        #         metal_layer = [CAMetalLayer layer];
+        #         [ns_window.contentView setLayer:metal_layer];
+        #         surface = wgpu_create_surface_from_metal_layer(metal_layer);
+        #     }
         layer = ffi.cast("void *", win_id)
         return _lib.wgpu_create_surface_from_metal_layer(layer)
     elif sys.platform.startswith("linux"):

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -1,5 +1,7 @@
+import os
 import sys
 import traceback
+import ctypes.util
 
 
 class BaseCanvas:
@@ -11,6 +13,7 @@ class BaseCanvas:
         super().__init__(*args, **kwargs)
         self._swapchain = None
         self._err_hashes = {}
+        self._display_id = None
 
     def configureSwapChain(self, device, format, usage):
         """ Configures the swap chain for this canvas, and returns a
@@ -69,3 +72,24 @@ class BaseCanvas:
         to obtain a surface id.
         """
         raise NotImplementedError()
+
+    def getDisplayId(self):
+        """ Get the native display id on Linux. This is needed by the backends
+        to obtain a surface id on Linux.
+        """
+        # Re-use to avoid creating loads of id's
+        if self._display_id is not None:
+            return self._display_id
+
+        if sys.platform.startswith("linux"):
+            is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+            if is_wayland:
+                raise NotImplementedError()
+            else:
+                x11 = ctypes.CDLL(ctypes.util.find_library("X11"))
+                x11.XOpenDisplay.restype = ctypes.c_void_p
+                self._display_id = x11.XOpenDisplay(None)
+        else:
+            raise RuntimeError(f"Cannot get display id on {sys.platform}.")
+
+        return self._display_id

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -84,7 +84,9 @@ class BaseCanvas:
         if sys.platform.startswith("linux"):
             is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
             if is_wayland:
-                raise NotImplementedError()
+                raise NotImplementedError(
+                    f"Cannot (yet) get display id on {self.__class__.__name__}."
+                )
             else:
                 x11 = ctypes.CDLL(ctypes.util.find_library("X11"))
                 x11.XOpenDisplay.restype = ctypes.c_void_p

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -47,7 +47,17 @@ if glfw_version_info < (1, 9):
         glfw.get_x11_display = glfw._glfw.glfwGetX11Display
 
 
-class WgpuCanvas(BaseCanvas):
+# Do checks to prevent pitfalls on hybrid Xorg/Wayland systems
+if sys.platform.startswith("linux"):
+    is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+    if is_wayland and not hasattr(glfw, "get_wayland_window"):
+        raise RuntimeError(
+            "We're on Wayland but Wayland functions not available. "
+            + "Did you apt install libglfw3-wayland?"
+        )
+
+
+class GlfwWgpuCanvas(BaseCanvas):
     """ A canvas object wrapping a glfw window.
     """
 
@@ -105,3 +115,6 @@ class WgpuCanvas(BaseCanvas):
 
     def isClosed(self):
         return glfw.window_should_close(self._window)
+
+
+WgpuCanvas = GlfwWgpuCanvas

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -33,10 +33,18 @@ if glfw_version_info < (1, 9):
         glfw._glfw.glfwGetWaylandWindow.restype = ctypes.c_void_p
         glfw._glfw.glfwGetWaylandWindow.argtypes = [ctypes.POINTER(glfw._GLFWwindow)]
         glfw.get_wayland_window = glfw._glfw.glfwGetWaylandWindow
+    if hasattr(glfw._glfw, "glfwGetWaylandDisplay"):
+        glfw._glfw.glfwGetWaylandDisplay.restype = ctypes.c_void_p
+        glfw._glfw.glfwGetWaylandDisplay.argtypes = []
+        glfw.get_wayland_display = glfw._glfw.glfwGetWaylandDisplay
     if hasattr(glfw._glfw, "glfwGetX11Window"):
         glfw._glfw.glfwGetX11Window.restype = ctypes.c_uint32
         glfw._glfw.glfwGetX11Window.argtypes = [ctypes.POINTER(glfw._GLFWwindow)]
         glfw.get_x11_window = glfw._glfw.glfwGetX11Window
+    if hasattr(glfw._glfw, "glfwGetX11Display"):
+        glfw._glfw.glfwGetX11Display.restype = ctypes.c_void_p
+        glfw._glfw.glfwGetX11Display.argtypes = []
+        glfw.get_x11_display = glfw._glfw.glfwGetX11Display
 
 
 class WgpuCanvas(BaseCanvas):
@@ -67,6 +75,16 @@ class WgpuCanvas(BaseCanvas):
         width, height = glfw.get_window_size(self._window)
         pixelratio = glfw.get_window_content_scale(self._window)[0]
         return width, height, pixelratio
+
+    def getDisplayId(self):
+        if sys.platform.startswith("linux"):
+            is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+            if is_wayland:
+                return glfw.get_wayland_display()
+            else:
+                return glfw.get_x11_display()
+        else:
+            raise RuntimeError(f"Cannot get GLFW display id on {sys.platform}.")
 
     def getWindowId(self):
         if sys.platform.startswith("win"):

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -51,5 +51,10 @@ class WgpuCanvas(BaseCanvas, QWidget):
     def isClosed(self):
         return not self.isVisible()
 
+    def getDisplayId(self):
+        # There is qx11info, but it is rarely available.
+        # https://doc.qt.io/qt-5/qx11info.html#display
+        return super().getDisplayId()  # use X11 lib
+
     def getWindowId(self):
         return int(self.winId())

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -21,7 +21,7 @@ else:
     )
 
 
-class WgpuCanvas(BaseCanvas, QWidget):
+class QtWgpuCanvas(BaseCanvas, QWidget):
     """ A QWidget subclass that can be used as a canvas to render to.
     """
 
@@ -58,3 +58,6 @@ class WgpuCanvas(BaseCanvas, QWidget):
 
     def getWindowId(self):
         return int(self.winId())
+
+
+WgpuCanvas = QtWgpuCanvas

--- a/wgpu/gui/tk.py
+++ b/wgpu/gui/tk.py
@@ -8,7 +8,7 @@ import tkinter
 from wgpu.gui.base import BaseCanvas
 
 
-class WgpuCanvas(BaseCanvas, tkinter.Toplevel):
+class TkWgpuCanvas(BaseCanvas, tkinter.Toplevel):
     """ A canvas object base on a Tkinter TopLevel window.
     """
 
@@ -57,3 +57,6 @@ class WgpuCanvas(BaseCanvas, tkinter.Toplevel):
     def _paint(self, *args):
         # Actual drawing needs to happen *after* Tcl draws bg
         self.after(1, self._drawFrameAndPresent)
+
+
+WgpuCanvas = TkWgpuCanvas

--- a/wgpu/gui/tk.py
+++ b/wgpu/gui/tk.py
@@ -41,10 +41,17 @@ class WgpuCanvas(BaseCanvas, tkinter.Toplevel):
         except Exception:
             return True
 
+    def getDisplayId(self):
+        return super().getDisplayId()
+
     def getWindowId(self):
+        # There's two functions of interest here. On Linux they return the same
+        # value (for a toplevel widget), but on Windows not, and frame() does
+        # not work.
+        # * self.winfo_id(): platform-specific identifier for window
+        # * self.frame(): platform specific window identifier for the
+        #   outermost frame that contains window
         return int(self.winfo_id())
-        # The docs seem to say that the below also produces the native window id,
-        # but the resulting int is different, and with it things don't work:
         # return int(self.frame(), 16)
 
     def _paint(self, *args):


### PR DESCRIPTION
* Adds methods to get the display id on glfw, and a generic approach that uses the X11 lib via ctypes.
* Updates readme.
* Rename canvas classes and provide an alias with a common name. That way you can see from the class what GUI backend is wrapped.

Closes #28, except:
* Does not work for tk for some reason.
* On Wayland only glfw works, because I don't know (yet) how to get the display id from Wayland. 