### PR TITLE
CI sdist and manylinux1 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,14 +13,11 @@ jobs:
         vmImage: ubuntu-16.04
         SDIST: 1
         LINT: 1
-        SEP: /
       MacOS:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
-        SEP: /
       Windows:
         vmImage: vs2017-win2016
-        SEP: \
   pool:
     vmImage: $(vmImage)
   steps:
@@ -105,7 +102,7 @@ jobs:
         python setup.py clean --all
         rm -rf ./wgpu
         pushd $AGENT_TEMPDIRECTORY
-        pip install ${BUILD_SOURCESDIRECTORY}${SEP}dist${SEP}*.whl
+        pip install $(echo "$(Build.SourcesDirectory)" | sed -e 's/\\/\//g')/dist/*.whl
         popd
         pytest --junit-xml=results-wheel.xml || true
         pip uninstall -y wgpu
@@ -132,7 +129,7 @@ jobs:
         set -ex
         rm -rf ./wgpu
         pushd $AGENT_TEMPDIRECTORY
-        pip install ${BUILD_SOURCESDIRECTORY}${SEP}dist${SEP}*.tar.gz
+        pip install $(echo "$(Build.SourcesDirectory)" | sed -e 's/\\/\//g')/dist/*.tar.gz
         popd
         # don't run tests, we just want to know if the sdist can be installed
         pip uninstall -y wgpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
         fi
   - task: PublishTestResults@2
     inputs:
-      testResultsFiles: results*.xml
+      testResultsFiles: results.xml
       mergeTestResults: true
       failTaskOnFailedTests: true
       testRunTitle: Test $(vmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ jobs:
     matrix:
       Linux:
         vmImage: ubuntu-16.04
+        FULL_BUILD: 1
       MacOS:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -32,14 +33,16 @@ jobs:
         python -m pip install -U pip
         pip install -U -r dev-requirements.txt
   - task: Bash@3
-    displayName: Restore WGPU native binary
+    displayName: Create source distribution
+    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
     inputs:
       targetType: inline
       script: |
         set -ex
-        python download-wgpu-native.py
+        python setup.py sdist
   - task: Bash@3
     displayName: Lint (black)
+    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
     inputs:
       targetType: inline
       script: |
@@ -47,11 +50,19 @@ jobs:
         black --check .
   - task: Bash@3
     displayName: Lint (flake8)
+    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
     inputs:
       targetType: inline
       script: |
         set -ex
         flake8
+  - task: Bash@3
+    displayName: Restore WGPU native binary
+    inputs:
+      targetType: inline
+      script: |
+        set -ex
+        python download-wgpu-native.py
   - task: Bash@3
     displayName: Build wheel and install in development mode
     inputs:
@@ -59,14 +70,14 @@ jobs:
       script: |
         set -ex
         python setup.py develop
-        python setup.py sdist bdist_wheel
+        python setup.py bdist_wheel
   - task: Bash@3
     displayName: Test
     inputs:
       targetType: inline
       script: |
         set -ex
-        pytest --disable-warnings --junit-xml=results.xml || true
+        pytest --junit-xml=results.xml || true
 
         # Fail the task if results.xml was not created
         if [[ ! -f results.xml ]]
@@ -76,38 +87,65 @@ jobs:
         fi
   - task: PublishTestResults@2
     inputs:
-      testResultsFiles: results.xml
+      testResultsFiles: results*.xml
       mergeTestResults: true
       failTaskOnFailedTests: true
       testRunTitle: Test $(vmImage)
   - task: Bash@3
-    displayName: Test (packaged)
+    displayName: Test wheel
     inputs:
       targetType: inline
       script: |
         set -ex
         python setup.py develop --uninstall
-        rm -rf ./wgpu ./build ./egg-info
+        python setup.py clean --all
+        rm -rf ./wgpu
         pip install dist/*.whl
-        pytest --disable-warnings --junit-xml=results-packaged.xml || true
+        pytest --junit-xml=results-wheel.xml || true
 
-        # Fail the task if results-packaged.xml was not created
-        if [[ ! -f results-packaged.xml ]]
+        # Fail the task if results-wheel.xml was not created
+        if [[ ! -f results-wheel.xml ]]
         then
           echo "##vso[task.logissue type=error]No test results were found"
           exit 1
         fi
   - task: PublishTestResults@2
     inputs:
-      testResultsFiles: results-packaged.xml
+      testResultsFiles: results-wheel.xml
       mergeTestResults: true
       failTaskOnFailedTests: true
-      testRunTitle: Test $(vmImage) (packaged)
+      testRunTitle: Test $(vmImage) (wheel)
+  - task: Bash@3
+    displayName: Test sdist
+    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+    inputs:
+      targetType: inline
+      script: |
+        set -ex
+        python setup.py develop --uninstall
+        python setup.py clean --all
+        rm -rf ./wgpu
+        pip install dist/*.tar.gz
+        pytest --junit-xml=results-sdist.xml || true
+
+        # Fail the task if results-sdist.xml was not created
+        if [[ ! -f results-sdist.xml ]]
+        then
+          echo "##vso[task.logissue type=error]No test results were found"
+          exit 1
+        fi
+  - task: PublishTestResults@2
+    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+    inputs:
+      testResultsFiles: results-sdist.xml
+      mergeTestResults: true
+      failTaskOnFailedTests: true
+      testRunTitle: Test $(vmImage) (sdist)
   - task: PublishBuildArtifacts@1
-    displayName: Publish wheels
+    displayName: Publish distributions
     inputs:
       pathtoPublish: dist
-      artifactName: wheels
+      artifactName: dist
 
 - job: Release
   dependsOn: Build
@@ -128,10 +166,10 @@ jobs:
         TAGS=$(git describe --tags)
         echo "##vso[task.setvariable variable=TAGS]$TAGS"
   - task: DownloadBuildArtifacts@0
-    displayName: Download wheels
+    displayName: Download dist
     condition: and(succeeded(), ne(variables['TAGS'], ''))
     inputs:
-      artifactName: wheels
+      artifactName: dist
       downloadPath: .
   - task: GithubRelease@1
     displayName: GitHub Release
@@ -139,7 +177,7 @@ jobs:
     inputs:
       gitHubConnection: github.com_almarklein
       repositoryName: 'almarklein/wgpu-py'
-      assets: 'wheels/*.whl'
+      assets: 'dist/*.whl'  # TODO: include sdist
       isDraft: true
       addChangeLog: false
       assetUploadMode: replace
@@ -158,11 +196,11 @@ jobs:
     inputs:
       pythonUploadServiceConnection: pypi
   - task: Bash@3
-    displayName: Upload wheels to PyPI
+    displayName: Upload dist to PyPI
     condition: and(succeeded(), ne(variables['TAGS'], ''))
     inputs:
       targetType: inline
       script: |
         set -ex
-        rm wheels/*linux*.whl
-        twine upload -r "wgpu" --config-file $(PYPIRC_PATH) --non-interactive wheels/*
+        rm dist/*linux*.whl
+        twine upload -r "wgpu" --config-file $(PYPIRC_PATH) --non-interactive dist/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,8 +140,11 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        set -ex
-        auditwheel addtag dist/*.whl
+        set -x
+        mkdir wheelhouse
+        auditwheel repair dist/*.whl || true
+        rm dist/*.whl
+        cp wheelhouse/*.whl dist/.
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
     inputs:
@@ -205,5 +208,4 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        rm dist/*linux*.whl  # TODO: ensure manylinux1 platform tag
         twine upload -r "wgpu" --config-file $(PYPIRC_PATH) --non-interactive dist/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,11 +13,14 @@ jobs:
         vmImage: ubuntu-16.04
         SDIST: 1
         LINT: 1
+        SEP: /
       MacOS:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
+        SEP: /
       Windows:
         vmImage: vs2017-win2016
+        SEP: \
   pool:
     vmImage: $(vmImage)
   steps:
@@ -32,6 +35,7 @@ jobs:
       script: |
         set -ex
         python -m pip install -U pip
+        pip install -U setuptools wheel
         pip install -U -r dev-requirements.txt
   - task: Bash@3
     displayName: Create source distribution
@@ -100,11 +104,13 @@ jobs:
         set -ex
         python setup.py develop --uninstall
         python setup.py clean --all
+        rm -rf ./wgpu
         pushd $AGENT_TEMPDIRECTORY
-        pip install $BUILD_SOURCESDIRECTORY/dist/*.whl
+        pip install $BUILD_SOURCESDIRECTORY$SEPdist$SEP*.whl
         popd
         pytest --junit-xml=results-wheel.xml || true
         pip uninstall -y wgpu
+        git restore ./wgpu
 
         # Fail the task if results-wheel.xml was not created
         if [[ ! -f results-wheel.xml ]]
@@ -125,11 +131,13 @@ jobs:
       targetType: inline
       script: |
         set -ex
+        rm -rf ./wgpu
         pushd $AGENT_TEMPDIRECTORY
-        pip install $BUILD_SOURCESDIRECTORY/dist/*.tar.gz
+        pip install $BUILD_SOURCESDIRECTORY$SEPdist$SEP*.tar.gz
         popd
         # don't run tests, we just want to know if the sdist can be installed
         pip uninstall -y wgpu
+        git restore ./wgpu
   - task: Bash@3
     displayName: Manylinux1 tag
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ jobs:
         python setup.py clean --all
         rm -rf ./wgpu
         pushd $AGENT_TEMPDIRECTORY
-        pip install $BUILD_SOURCESDIRECTORY$SEPdist$SEP*.whl
+        pip install ${BUILD_SOURCESDIRECTORY}${SEP}dist${SEP}*.whl
         popd
         pytest --junit-xml=results-wheel.xml || true
         pip uninstall -y wgpu
@@ -133,7 +133,7 @@ jobs:
         set -ex
         rm -rf ./wgpu
         pushd $AGENT_TEMPDIRECTORY
-        pip install $BUILD_SOURCESDIRECTORY$SEPdist$SEP*.tar.gz
+        pip install ${BUILD_SOURCESDIRECTORY}${SEP}dist${SEP}*.tar.gz
         popd
         # don't run tests, we just want to know if the sdist can be installed
         pip uninstall -y wgpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,6 @@ jobs:
       script: |
         set -ex
         python -m pip install -U pip
-        pip install -U setuptools wheel
         pip install -U -r dev-requirements.txt
   - task: Bash@3
     displayName: Create source distribution

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,14 +137,14 @@ jobs:
   - task: Bash@3
     displayName: Manylinux1 tag
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    continueOnError: true
     inputs:
       targetType: inline
       script: |
-        set -x
-        mkdir wheelhouse
-        auditwheel repair dist/*.whl || true
+        set -ex
+        auditwheel repair dist/*.whl
         rm dist/*.whl
-        cp wheelhouse/*.whl dist/. || true
+        cp wheelhouse/*.whl dist/.
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,6 +142,8 @@ jobs:
       targetType: inline
       script: |
         set -ex
+        sudo apt-get update
+        sudo apt-get install -y patchelf
         auditwheel repair dist/*.whl
         rm dist/*.whl
         cp wheelhouse/*.whl dist/.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ jobs:
       script: |
         set -ex
         pushd $AGENT_TEMPDIRECTORY
-        pip install dist/*.tar.gz
+        pip install $BUILD_SOURCESDIRECTORY/dist/*.tar.gz
         popd
         # don't run tests, we just want to know if the sdist can be installed
         pip uninstall -y wgpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
         python setup.py develop --uninstall
         python setup.py clean --all
         pushd $AGENT_TEMPDIRECTORY
-        pip install $BUILD_SOURCESDIRECTORY)/dist/*.whl
+        pip install $BUILD_SOURCESDIRECTORY/dist/*.whl
         popd
         pytest --junit-xml=results-wheel.xml || true
         pip uninstall -y wgpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,6 +147,13 @@ jobs:
         auditwheel repair dist/*.whl
         rm dist/*.whl
         cp wheelhouse/*.whl dist/.
+  - task: Bash@3
+    displayName: Twine check
+    inputs:
+      targetType: inline
+      script: |
+        set -ex
+        twine check dist/*
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,4 +208,5 @@ jobs:
       targetType: inline
       script: |
         set -ex
+        rm dist/*linux*.whl  # TODO: ensure manylinux1 platform tag
         twine upload -r "wgpu" --config-file $(PYPIRC_PATH) --non-interactive dist/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,5 +199,5 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        rm dist/*linux*.whl
+        rm dist/*linux*.whl  # TODO: ensure manylinux1 platform tag
         twine upload -r "wgpu" --config-file $(PYPIRC_PATH) --non-interactive dist/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,7 @@ jobs:
         mkdir wheelhouse
         auditwheel repair dist/*.whl || true
         rm dist/*.whl
-        cp wheelhouse/*.whl dist/.
+        cp wheelhouse/*.whl dist/. || true
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,9 @@ jobs:
       targetType: inline
       script: |
         set -ex
+        pushd $TMP
         pip install dist/*.tar.gz
+        popd
         # don't run tests, we just want to know if the sdist can be installed
         pip uninstall -y wgpu
   - task: Bash@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ jobs:
         set -ex
         python setup.py develop --uninstall
         python setup.py clean --all
-        pushd $TMP
+        pushd $AGENT_TEMPDIRECTORY
         pip install $BUILD_SOURCESDIRECTORY)/dist/*.whl
         popd
         pytest --junit-xml=results-wheel.xml || true
@@ -125,7 +125,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        pushd $TMP
+        pushd $AGENT_TEMPDIRECTORY
         pip install dist/*.tar.gz
         popd
         # don't run tests, we just want to know if the sdist can be installed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,8 @@ jobs:
     matrix:
       Linux:
         vmImage: ubuntu-16.04
-        FULL_BUILD: 1
+        SDIST: 1
+        LINT: 1
       MacOS:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -34,7 +35,7 @@ jobs:
         pip install -U -r dev-requirements.txt
   - task: Bash@3
     displayName: Create source distribution
-    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+    condition: and(succeeded(), eq(variables['SDIST'], '1'))
     inputs:
       targetType: inline
       script: |
@@ -42,7 +43,7 @@ jobs:
         python setup.py sdist
   - task: Bash@3
     displayName: Lint (black)
-    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+    condition: and(succeeded(), eq(variables['LINT'], '1'))
     inputs:
       targetType: inline
       script: |
@@ -50,7 +51,7 @@ jobs:
         black --check .
   - task: Bash@3
     displayName: Lint (flake8)
-    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+    condition: and(succeeded(), eq(variables['LINT'], '1'))
     inputs:
       targetType: inline
       script: |
@@ -99,9 +100,11 @@ jobs:
         set -ex
         python setup.py develop --uninstall
         python setup.py clean --all
-        rm -rf ./wgpu
-        pip install dist/*.whl
+        pushd $TMP
+        pip install $BUILD_SOURCESDIRECTORY)/dist/*.whl
+        popd
         pytest --junit-xml=results-wheel.xml || true
+        pip uninstall -y wgpu
 
         # Fail the task if results-wheel.xml was not created
         if [[ ! -f results-wheel.xml ]]
@@ -117,30 +120,22 @@ jobs:
       testRunTitle: Test $(vmImage) (wheel)
   - task: Bash@3
     displayName: Test sdist
-    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+    condition: and(succeeded(), eq(variables['SDIST'], '1'))
     inputs:
       targetType: inline
       script: |
         set -ex
-        python setup.py develop --uninstall
-        python setup.py clean --all
-        rm -rf ./wgpu
         pip install dist/*.tar.gz
-        pytest --junit-xml=results-sdist.xml || true
-
-        # Fail the task if results-sdist.xml was not created
-        if [[ ! -f results-sdist.xml ]]
-        then
-          echo "##vso[task.logissue type=error]No test results were found"
-          exit 1
-        fi
-  - task: PublishTestResults@2
-    condition: and(succeeded(), eq(variables['FULL_BUILD'], '1'))
+        # don't run tests, we just want to know if the sdist can be installed
+        pip uninstall -y wgpu
+  - task: Bash@3
+    displayName: Manylinux1 tag
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
     inputs:
-      testResultsFiles: results-sdist.xml
-      mergeTestResults: true
-      failTaskOnFailedTests: true
-      testRunTitle: Test $(vmImage) (sdist)
+      targetType: inline
+      script: |
+        set -ex
+        auditwheel addtag dist/*.whl
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
     inputs:
@@ -177,7 +172,9 @@ jobs:
     inputs:
       gitHubConnection: github.com_almarklein
       repositoryName: 'almarklein/wgpu-py'
-      assets: 'dist/*.whl'  # TODO: include sdist
+      assets: |
+        dist/*.whl
+        dist/*.tar.gz
       isDraft: true
       addChangeLog: false
       assetUploadMode: replace

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,6 @@ pytest
 flake8
 requests
 setuptools
-wheel
+wheel==0.31.1
 twine
 auditwheel; sys_platform == 'linux'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ requests
 setuptools
 wheel
 twine
+auditwheel; sys_platform == 'linux'

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     package_data={f"{NAME}.resources": resources_globs},
     python_requires=">=3.6.0",
     install_requires=runtime_deps,
-    license=open("LICENSE").read(),
+    license="BSD 2-Clause",
     description=SUMMARY,
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setup(
     author_email="almar.klein@gmail.com",
     url="https://github.com/almarklein/wgpu-py",
     cmdclass={"bdist_wheel": bdist_wheel},
+    data_files=[("", ["LICENSE"])],
 )


### PR DESCRIPTION
* Run linting on one platform to save some time
* Use auditwheel on Linux
* Build sdist on Linux
* Test installing wheels and sdists from temp folder so we can catch problems like in #38 in CI
* Include `LICENSE` file in built package
* Ensure binaries are not included in sdist
* Pin wheel==0.31.1, see https://github.com/pypa/auditwheel/issues/102
* Don't include the LICENSE file in the license kwarg, see https://github.com/pypa/setuptools/issues/1390
* For now, release step removes linux wheels just before uploading since they are not manylinux1 compliant

Closes #38