### PR TITLE
Convert API to snake_case

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 black
 pytest
 flake8
+pep8-naming
 requests
 setuptools
 wheel

--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -30,10 +30,9 @@ def write_current_version(version):
 
 
 def download_file(url, filename):
-    CHUNK_SIZE = 1024 * 128
     resp = requests.get(url, stream=True)
     with open(filename, mode="wb") as fh:
-        for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
+        for chunk in resp.iter_content(chunk_size=1024 * 128):
             fh.write(chunk)
 
 

--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -55,15 +55,15 @@ print(result[:])
 # %% The long version using the wgpu API
 
 # Create device and shader object
-adapter = wgpu.requestAdapter(powerPreference="high-performance")
-device = adapter.requestDevice(extensions=[], limits=wgpu.GPULimits())
-cshader = device.createShaderModule(code=compute_shader)
+adapter = wgpu.request_adapter(power_preference="high-performance")
+device = adapter.request_device(extensions=[], limits={})
+cshader = device.create_shader_module(code=compute_shader)
 
 # Create buffer objects, input buffer is mapped.
-buffer1 = device.createBufferMapped(
+buffer1 = device.create_buffer_mapped(
     size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ
 )
-buffer2 = device.createBuffer(
+buffer2 = device.create_buffer(
     size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ
 )
 
@@ -95,24 +95,24 @@ bindings = [
 ]
 
 # Put everything together
-bind_group_layout = device.createBindGroupLayout(bindings=binding_layouts)
-pipeline_layout = device.createPipelineLayout(bindGroupLayouts=[bind_group_layout])
-bind_group = device.createBindGroup(layout=bind_group_layout, bindings=bindings)
+bind_group_layout = device.create_bind_group_layout(bindings=binding_layouts)
+pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[bind_group_layout])
+bind_group = device.create_bind_group(layout=bind_group_layout, bindings=bindings)
 
 # Create and run the pipeline
-compute_pipeline = device.createComputePipeline(
-    layout=pipeline_layout, computeStage={"module": cshader, "entryPoint": "main"},
+compute_pipeline = device.create_compute_pipeline(
+    layout=pipeline_layout, compute_stage={"module": cshader, "entry_point": "main"},
 )
-command_encoder = device.createCommandEncoder()
-compute_pass = command_encoder.beginComputePass()
-compute_pass.setPipeline(compute_pipeline)
-compute_pass.setBindGroup(0, bind_group, [], 0, 999999)  # last 2 elements not used
+command_encoder = device.create_command_encoder()
+compute_pass = command_encoder.begin_compute_pass()
+compute_pass.set_pipeline(compute_pipeline)
+compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 elements not used
 compute_pass.dispatch(n, 1, 1)  # x y z
-compute_pass.endPass()
-device.defaultQueue.submit([command_encoder.finish()])
+compute_pass.end_pass()
+device.default_queue.submit([command_encoder.finish()])
 
 # Read result
-result = buffer2.mapRead()
+result = buffer2.map_read()
 result = IntArrayType.from_buffer(result)  # cast
 print(result[:])
 

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -105,12 +105,12 @@ def _main(canvas, device):
         alphaToCoverageEnabled=False,
     )
 
-    swap_chain = canvas.configureSwapChain(
+    swap_chain = canvas.configure_swap_chain(
         device, wgpu.TextureFormat.bgra8unorm_srgb, wgpu.TextureUsage.OUTPUT_ATTACHMENT
     )
 
     def drawFrame():
-        current_texture_view = swap_chain.getCurrentTextureView()
+        current_texture_view = swap_chain.get_current_texture_view()
         command_encoder = device.createCommandEncoder()
 
         render_pass = command_encoder.beginRenderPass(

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -47,90 +47,92 @@ def fragment_shader(
 def main(canvas):
     """ Regular function to setup a viz on the given canvas.
     """
-    adapter = wgpu.requestAdapter(powerPreference="high-performance")
-    device = adapter.requestDevice(extensions=[], limits=wgpu.GPULimits())
+    adapter = wgpu.request_adapter(power_preference="high-performance")
+    device = adapter.request_device(extensions=[], limits={})
     return _main(canvas, device)
 
 
-async def mainAsync(canvas):
+async def main_async(canvas):
     """ Async function to setup a viz on the given canvas.
     """
-    adapter = await wgpu.requestAdapterAsync(powerPreference="high-performance")
-    device = await adapter.requestDeviceAsync(extensions=[], limits=wgpu.GPULimits())
+    adapter = await wgpu.request_adapter_async(power_preference="high-performance")
+    device = await adapter.request_device_async(extensions=[], limits={})
     return _main(canvas, device)
 
 
 def _main(canvas, device):
 
-    vshader = device.createShaderModule(code=vertex_shader)
-    fshader = device.createShaderModule(code=fragment_shader)
+    vshader = device.create_shader_module(code=vertex_shader)
+    fshader = device.create_shader_module(code=fragment_shader)
 
-    bind_group_layout = device.createBindGroupLayout(bindings=[])  # zero bindings
-    bind_group = device.createBindGroup(layout=bind_group_layout, bindings=[])
+    bind_group_layout = device.create_bind_group_layout(bindings=[])  # zero bindings
+    bind_group = device.create_bind_group(layout=bind_group_layout, bindings=[])
 
-    pipeline_layout = device.createPipelineLayout(bindGroupLayouts=[bind_group_layout])
+    pipeline_layout = device.create_pipeline_layout(
+        bind_group_layouts=[bind_group_layout]
+    )
 
-    render_pipeline = device.createRenderPipeline(
+    render_pipeline = device.create_render_pipeline(
         layout=pipeline_layout,
-        vertexStage={"module": vshader, "entryPoint": "main"},
-        fragmentStage={"module": fshader, "entryPoint": "main"},
-        primitiveTopology=wgpu.PrimitiveTopology.triangle_list,
-        rasterizationState={
-            "frontFace": wgpu.FrontFace.ccw,
-            "cullMode": wgpu.CullMode.none,
-            "depthBias": 0,
-            "depthBiasSlopeScale": 0.0,
-            "depthBiasClamp": 0.0,
+        vertex_stage={"module": vshader, "entry_point": "main"},
+        fragment_stage={"module": fshader, "entry_point": "main"},
+        primitive_topology=wgpu.PrimitiveTopology.triangle_list,
+        rasterization_state={
+            "front_face": wgpu.FrontFace.ccw,
+            "cull_mode": wgpu.CullMode.none,
+            "depth_bias": 0,
+            "depth_bias_slope_scale": 0.0,
+            "depth_bias_clamp": 0.0,
         },
-        colorStates=[
+        color_states=[
             {
                 "format": wgpu.TextureFormat.bgra8unorm_srgb,
-                "alphaBlend": (
+                "alpha_blend": (
                     wgpu.BlendFactor.one,
                     wgpu.BlendFactor.zero,
                     wgpu.BlendOperation.add,
                 ),
-                "colorBlend": (
+                "color_blend": (
                     wgpu.BlendFactor.one,
                     wgpu.BlendFactor.zero,
                     wgpu.BlendOperation.add,
                 ),
-                "writeMask": wgpu.ColorWrite.ALL,
+                "write_mask": wgpu.ColorWrite.ALL,
             }
         ],
-        depthStencilState=None,
-        vertexState={"indexFormat": wgpu.IndexFormat.uint32, "vertexBuffers": []},
-        sampleCount=1,
-        sampleMask=0xFFFFFFFF,
-        alphaToCoverageEnabled=False,
+        depth_stencil_state=None,
+        vertex_state={"index_format": wgpu.IndexFormat.uint32, "vertex_buffers": []},
+        sample_count=1,
+        sample_mask=0xFFFFFFFF,
+        alpha_to_coverage_enabled=False,
     )
 
     swap_chain = canvas.configure_swap_chain(
         device, wgpu.TextureFormat.bgra8unorm_srgb, wgpu.TextureUsage.OUTPUT_ATTACHMENT
     )
 
-    def drawFrame():
+    def draw_frame():
         current_texture_view = swap_chain.get_current_texture_view()
-        command_encoder = device.createCommandEncoder()
+        command_encoder = device.create_command_encoder()
 
-        render_pass = command_encoder.beginRenderPass(
-            colorAttachments=[
+        render_pass = command_encoder.begin_render_pass(
+            color_attachments=[
                 {
                     "attachment": current_texture_view,
-                    "resolveTarget": None,
-                    "loadValue": (0, 0, 0, 1),  # LoadOp.load or color
-                    "storeOp": wgpu.StoreOp.store,
+                    "resolve_target": None,
+                    "load_value": (0, 0, 0, 1),  # LoadOp.load or color
+                    "store_op": wgpu.StoreOp.store,
                 }
             ],
-            depthStencilAttachment=None,
+            depth_stencil_attachment=None,
         )
 
-        render_pass.setPipeline(render_pipeline)
-        render_pass.setBindGroup(
+        render_pass.set_pipeline(render_pipeline)
+        render_pass.set_bind_group(
             0, bind_group, [], 0, 999999
         )  # last 2 elements not used
         render_pass.draw(3, 1, 0, 0)
-        render_pass.endPass()
-        device.defaultQueue.submit([command_encoder.finish()])
+        render_pass.end_pass()
+        device.default_queue.submit([command_encoder.finish()])
 
-    canvas.drawFrame = drawFrame
+    canvas.draw_frame = draw_frame

--- a/examples/triangle_glfw.py
+++ b/examples/triangle_glfw.py
@@ -15,6 +15,6 @@ glfw.init()
 canvas = WgpuCanvas(size=(640, 480), title="wgpu triangle with GLFW")
 
 main(canvas)
-while not canvas.isClosed():
+while not canvas.is_closed():
     glfw.poll_events()
 glfw.terminate()

--- a/examples/triangle_glfw_asyncio.py
+++ b/examples/triangle_glfw_asyncio.py
@@ -11,16 +11,16 @@ from wgpu.gui.glfw import WgpuCanvas  # WgpuCanvas wraps a glfw window
 import wgpu.backend.rs  # noqa: F401, Select Rust backend
 
 # Import the (async) function that we must call to run the visualization
-from triangle import mainAsync
+from triangle import main_async
 
 
 glfw.init()
 canvas = WgpuCanvas(size=(640, 480), title="wgpu triangle with GLFW")
 
 
-async def mainLoop():
-    await mainAsync(canvas)
-    while not canvas.isClosed():
+async def mainloop():
+    await main_async(canvas)
+    while not canvas.is_closed():
         await asyncio.sleep(0.001)
         glfw.poll_events()
     loop.stop()
@@ -29,5 +29,5 @@ async def mainLoop():
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
-    loop.create_task(mainLoop())
+    loop.create_task(mainloop())
     loop.run_forever()

--- a/examples/triangle_qt.py
+++ b/examples/triangle_qt.py
@@ -21,9 +21,9 @@ app.exec_()
 # For those interested, this is a simple way to integrate Qt's event
 # loop with asyncio, but for real apps you probably want to use
 # something like the qasync library.
-# async def mainLoop():
-#     await mainAsync(canvas)
-#     while not canvas.isClosed():
+# async def mainloop():
+#     await main_async(canvas)
+#     while not canvas.is_closed():
 #         await asyncio.sleep(0.001)
 #         app.flush()
 #         app.processEvents()

--- a/examples/triangle_tk.py
+++ b/examples/triangle_tk.py
@@ -17,7 +17,7 @@ canvas = WgpuCanvas(size=(640, 480), title="wgpu triangle with Tkinter")
 
 main(canvas)
 
-while not canvas.isClosed():
+while not canvas.is_closed():
     root.update_idletasks()
     root.update()
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(f"{NAME}/__init__.py") as fh:
     VERSION = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
 
 
-class bdist_wheel(_bdist_wheel):
+class bdist_wheel(_bdist_wheel):  # noqa: N801
     def finalize_options(self):
         self.plat_name = get_platform(None)  # force a platform tag
         _bdist_wheel.finalize_options(self)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,8 +9,8 @@ def test_stub():
 
     assert wgpu.__version__
     assert wgpu.help
-    assert wgpu.requestAdapter
-    assert wgpu.requestAdapterAsync
+    assert wgpu.request_adapter
+    assert wgpu.request_adapter_async
 
 
 def get_output_from_subprocess(code):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -19,8 +19,7 @@ def _determine_can_use_vulkan_sdk():
 
 
 def _determine_can_use_wgpu_lib():
-    code = "import wgpu.backend.rs;"
-    code += "wgpu.request_adapter(power_preference='high-performance').request_device()"
+    code = "import wgpu.utils; wgpu.utils.create_device()"
     try:
         subprocess.check_output(
             [sys.executable, "-c", code,]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -20,7 +20,7 @@ def _determine_can_use_vulkan_sdk():
 
 def _determine_can_use_wgpu_lib():
     code = "import wgpu.backend.rs;"
-    code += "wgpu.requestAdapter(powerPreference='high-performance').requestDevice()"
+    code += "wgpu.request_adapter(power_preference='high-performance').request_device()"
     try:
         subprocess.check_output(
             [sys.executable, "-c", code,]

--- a/wgpu/__init__.py
+++ b/wgpu/__init__.py
@@ -9,17 +9,17 @@ __version__ = "0.1.4"
 
 
 def _register_backend(func, func_async):
-    if not (callable(func) and func.__name__ == "requestAdapter"):
+    if not (callable(func) and func.__name__ == "request_adapter"):
         raise RuntimeError(
-            "WGPU backend must be registered with function called requestAdapterSync."
+            "WGPU backend must be registered with function called request_adapter."
         )
-    if not (callable(func_async) and func_async.__name__ == "requestAdapterAsync"):
+    if not (callable(func_async) and func_async.__name__ == "request_adapter_async"):
         raise RuntimeError(
-            "WGPU backend must be registered with function called requestAdapterAsync."
+            "WGPU backend must be registered with function called request_adapter_async."
         )
-    if globals()["requestAdapter"] is not base.requestAdapter:
+    if globals()["request_adapter"] is not base.request_adapter:
         raise RuntimeError("WGPU backend can only be set once.")
-    globals()["requestAdapter"] = func
-    globals()["requestAdapterAsync"] = func_async
+    globals()["request_adapter"] = func
+    globals()["request_adapter_async"] = func_async
 
-    # todo: auto-select upon using requestAdapter?
+    # todo: auto-select upon using request_adapter?

--- a/wgpu/_coreutils.py
+++ b/wgpu/_coreutils.py
@@ -37,7 +37,7 @@ def help(*searches, dev=False):
     all_lines = []  # list of (title, lines_list)
 
     if dev:
-        from ._parsers import IdlParser, HParser
+        from ._parsers import IdlParser, HParser, to_neutral_name
 
         filename = os.path.join(get_resource_filename("webgpu.idl"))
         idl_parser = IdlParser(open(filename, "rb").read().decode())
@@ -132,7 +132,7 @@ def help(*searches, dev=False):
     lines = []
     all_lines.append(("functions", lines))
     for name_part in name_parts:
-        name_part_f = name_part.replace("_", "").replace(".", "")
+        name_part_f = to_neutral_name(name_part)
         for cls in m_classes.__dict__.values():
             if isinstance(cls, type):
                 for attr_name, attr in cls.__dict__.items():

--- a/wgpu/backend/js.py
+++ b/wgpu/backend/js.py
@@ -11,13 +11,13 @@ from .. import _register_backend
 from pscript.stubs import window
 
 
-def requestAdapter(options):
+def request_adapter(options):
     raise NotImplementedError("Cannot use sync API functions in JS.")
 
 
-async def requestAdapterASync(options):
-    return await window.navigator.gpu.requestAdapter(options)
+async def request_adapter_async(options):
+    return await window.navigator.gpu.request_adapter(options)
 
 
 # Mark as the backend on import time
-_register_backend(requestAdapter, requestAdapterASync)
+_register_backend(request_adapter, request_adapter_async)

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -129,7 +129,7 @@ def new_struct(ctype, **kwargs):
 
 
 def get_surface_id_from_canvas(canvas):
-    win_id = canvas.getWindowId()
+    win_id = canvas.get_window_id()
     if sys.platform.startswith("win"):
         # wgpu_create_surface_from_windows_hwnd(void *_hinstance, void *hwnd)
         hwnd = ffi.cast("void *", int(win_id))
@@ -153,7 +153,7 @@ def get_surface_id_from_canvas(canvas):
     elif sys.platform.startswith("linux"):
         # wgpu_create_surface_from_wayland(void *surface, void *display)
         # wgpu_create_surface_from_xlib(const void **display, uint64_t window)
-        display_id = canvas.getDisplayId()
+        display_id = canvas.get_display_id()
         is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
         if is_wayland:
             # todo: works, but have not yet been able to test drawing to the window
@@ -180,7 +180,9 @@ def request_adapter(*, power_preference: "GPUPowerPreference"):
     """
 
     # Convert the descriptor
-    struct = new_struct("WGPURequestAdapterOptions *", power_preference=power_preference)
+    struct = new_struct(
+        "WGPURequestAdapterOptions *", power_preference=power_preference
+    )
 
     # Select possible backends. This is not exposed in the WebGPU API
     # 1 => Backend::Empty,
@@ -922,7 +924,7 @@ class GPUSwapChain(base.GPUSwapChain):
         self._create_native_swap_chain_if_needed()
 
     def _create_native_swap_chain_if_needed(self):
-        cur_size = self._canvas.getSizeAndPixelRatio()  # width, height, ratio
+        cur_size = self._canvas.get_size_and_pixel_ratio()  # width, height, ratio
         if cur_size == self._surface_size:
             return
 

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -171,7 +171,7 @@ def get_surface_id_from_canvas(canvas):
 
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
-def requestAdapter(*, powerPreference: "GPUPowerPreference"):
+def request_adapter(*, power_preference: "GPUPowerPreference"):
     """ Request an GPUAdapter, the object that represents the implementation of WGPU.
     This function uses the Rust WGPU library.
 
@@ -213,7 +213,7 @@ def requestAdapter(*, powerPreference: "GPUPowerPreference"):
 
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
-async def requestAdapterAsync(*, powerPreference: "GPUPowerPreference"):
+async def request_adapter_async(*, power_preference: "GPUPowerPreference"):
     """ Async version of ``requestAdapter()``.
     This function uses the Rust WGPU library.
     """
@@ -230,7 +230,7 @@ class GPUAdapter(base.GPUAdapter):
         self._id = id
 
     # wgpu.help('DeviceDescriptor', 'adapterrequestdevice', dev=True)
-    def requestDevice(
+    def request_device(
         self,
         *,
         label="",
@@ -259,7 +259,7 @@ class GPUAdapter(base.GPUAdapter):
         return GPUDevice(label, id, self, extensions, limits, queue)
 
     # wgpu.help('DeviceDescriptor', 'adapterrequestdevice', dev=True)
-    async def requestDeviceAsync(
+    async def request_device_async(
         self,
         *,
         label="",
@@ -270,9 +270,8 @@ class GPUAdapter(base.GPUAdapter):
 
 
 class GPUDevice(base.GPUDevice):
-
     # wgpu.help('BufferDescriptor', 'devicecreatebuffer', dev=True)
-    def createBuffer(
+    def create_buffer(
         self, *, label="", size: "GPUSize64", usage: "GPUBufferUsageFlags"
     ):
         size = int(size)
@@ -283,7 +282,7 @@ class GPUDevice(base.GPUDevice):
         return GPUBuffer(label, id, self, size, usage, "unmapped", None)
 
     # wgpu.help('BufferDescriptor', 'devicecreatebuffermapped', dev=True)
-    def createBufferMapped(
+    def create_buffer_mapped(
         self, *, label="", size: "GPUSize64", usage: "GPUBufferUsageFlags"
     ):
 
@@ -306,7 +305,7 @@ class GPUDevice(base.GPUDevice):
         return GPUBuffer(label, id, self, size, usage, "mapped", mem_as_ctypes)
 
     # wgpu.help('BindGroupLayoutDescriptor', 'devicecreatebindgrouplayout', dev=True)
-    def createBindGroupLayout(
+    def create_bind_group_layout(
         self, *, label="", bindings: "GPUBindGroupLayoutBinding-list"
     ):
 
@@ -336,7 +335,7 @@ class GPUDevice(base.GPUDevice):
         return base.GPUBindGroupLayout(label, id, self, bindings)
 
     # wgpu.help('BindGroupDescriptor', 'devicecreatebindgroup', dev=True)
-    def createBindGroup(
+    def create_bind_group(
         self,
         *,
         label="",
@@ -396,8 +395,8 @@ class GPUDevice(base.GPUDevice):
         return base.GPUBindGroup(label, id, self, bindings)
 
     # wgpu.help('PipelineLayoutDescriptor', 'devicecreatepipelinelayout', dev=True)
-    def createPipelineLayout(
-        self, *, label="", bindGroupLayouts: "GPUBindGroupLayout-list"
+    def create_pipeline_layout(
+        self, *, label="", bind_group_layouts: "GPUBindGroupLayout-list"
     ):
 
         bindGroupLayouts_ids = [x._internal for x in bindGroupLayouts]
@@ -413,7 +412,7 @@ class GPUDevice(base.GPUDevice):
         return base.GPUPipelineLayout(label, id, self, bindGroupLayouts)
 
     # wgpu.help('ShaderModuleDescriptor', 'devicecreateshadermodule', dev=True)
-    def createShaderModule(self, *, label="", code: "GPUShaderCode"):
+    def create_shader_module(self, *, label="", code: "GPUShaderCode"):
 
         if isinstance(code, bytes):
             data = code  # Assume it's Spirv
@@ -441,12 +440,12 @@ class GPUDevice(base.GPUDevice):
         return base.GPUShaderModule(label, id, self)
 
     # wgpu.help('ComputePipelineDescriptor', 'devicecreatecomputepipeline', dev=True)
-    def createComputePipeline(
+    def create_compute_pipeline(
         self,
         *,
         label="",
         layout: "GPUPipelineLayout",
-        computeStage: "GPUProgrammableStageDescriptor",
+        compute_stage: "GPUProgrammableStageDescriptor",
     ):
 
         c_compute_stage = new_struct(
@@ -465,21 +464,21 @@ class GPUDevice(base.GPUDevice):
         return base.GPUComputePipeline(label, id, self)
 
     # wgpu.help('RenderPipelineDescriptor', 'devicecreaterenderpipeline', dev=True)
-    def createRenderPipeline(
+    def create_render_pipeline(
         self,
         *,
         label="",
         layout: "GPUPipelineLayout",
-        vertexStage: "GPUProgrammableStageDescriptor",
-        fragmentStage: "GPUProgrammableStageDescriptor",
-        primitiveTopology: "GPUPrimitiveTopology",
-        rasterizationState: "GPURasterizationStateDescriptor" = {},
-        colorStates: "GPUColorStateDescriptor-list",
-        depthStencilState: "GPUDepthStencilStateDescriptor",
-        vertexState: "GPUVertexStateDescriptor" = {},
-        sampleCount: "GPUSize32" = 1,
-        sampleMask: "GPUSampleMask" = 0xFFFFFFFF,
-        alphaToCoverageEnabled: bool = False,
+        vertex_stage: "GPUProgrammableStageDescriptor",
+        fragment_stage: "GPUProgrammableStageDescriptor",
+        primitive_topology: "GPUPrimitiveTopology",
+        rasterization_state: "GPURasterizationStateDescriptor" = {},
+        color_states: "GPUColorStateDescriptor-list",
+        depth_stencil_state: "GPUDepthStencilStateDescriptor",
+        vertex_state: "GPUVertexStateDescriptor" = {},
+        sample_count: "GPUSize32" = 1,
+        sample_mask: "GPUSampleMask" = 0xFFFFFFFF,
+        alpha_to_coverage_enabled: bool = False,
     ):
         c_vertex_stage = new_struct(
             "WGPUProgrammableStageDescriptor *",
@@ -604,7 +603,7 @@ class GPUDevice(base.GPUDevice):
         return base.GPURenderPipeline(label, id, self)
 
     # wgpu.help('CommandEncoderDescriptor', 'devicecreatecommandencoder', dev=True)
-    def createCommandEncoder(self, *, label=""):
+    def create_command_encoder(self, *, label=""):
 
         struct = new_struct("WGPUCommandEncoderDescriptor *", todo=0)
 
@@ -620,7 +619,7 @@ class GPUDevice(base.GPUDevice):
 
 class GPUBuffer(base.GPUBuffer):
     # wgpu.help('buffermapreadasync', dev=True)
-    def mapRead(self):
+    def map_read(self):
         data = None
 
         @ffi.callback("void(WGPUBufferMapAsyncStatus, uint8_t*, uint8_t*)")
@@ -645,7 +644,7 @@ class GPUBuffer(base.GPUBuffer):
         return data
 
     # wgpu.help('buffermapreadasync', dev=True)
-    async def mapReadAsync(self):
+    async def map_read_async(self):
         # todo: actually make this async
         return self.mapRead()
 
@@ -663,19 +662,18 @@ class GPUBuffer(base.GPUBuffer):
 
 
 class GPUTexture(base.GPUTexture):
-
     # wgpu.help('TextureViewDescriptor', 'texturecreateview', dev=True)
-    def createView(
+    def create_view(
         self,
         *,
         label="",
         format: "GPUTextureFormat",
         dimension: "GPUTextureViewDimension",
         aspect: "GPUTextureAspect" = "all",
-        baseMipLevel: "GPUIntegerCoordinate" = 0,
-        mipLevelCount: "GPUIntegerCoordinate" = 0,
-        baseArrayLayer: "GPUIntegerCoordinate" = 0,
-        arrayLayerCount: "GPUIntegerCoordinate" = 0,
+        base_mip_level: "GPUIntegerCoordinate" = 0,
+        mip_level_count: "GPUIntegerCoordinate" = 0,
+        base_array_layer: "GPUIntegerCoordinate" = 0,
+        array_layer_count: "GPUIntegerCoordinate" = 0,
     ):
 
         struct = new_struct(
@@ -697,20 +695,19 @@ class GPUTexture(base.GPUTexture):
 
 
 class GPUCommandEncoder(base.GPUCommandEncoder):
-
     # wgpu.help('ComputePassDescriptor', 'commandencoderbegincomputepass', dev=True)
-    def beginComputePass(self, *, label=""):
+    def begin_compute_pass(self, *, label=""):
         struct = new_struct("WGPUComputePassDescriptor *", todo=0)
         raw_pass = _lib.wgpu_command_encoder_begin_compute_pass(self._internal, struct)
         return GPUComputePassEncoder(label, raw_pass, self)
 
     # wgpu.help('RenderPassDescriptor', 'commandencoderbeginrenderpass', dev=True)
-    def beginRenderPass(
+    def begin_render_pass(
         self,
         *,
         label="",
-        colorAttachments: "GPURenderPassColorAttachmentDescriptor-list",
-        depthStencilAttachment: "GPURenderPassDepthStencilAttachmentDescriptor",
+        color_attachments: "GPURenderPassColorAttachmentDescriptor-list",
+        depth_stencil_attachment: "GPURenderPassDepthStencilAttachmentDescriptor",
     ):
 
         c_color_attachments_list = []
@@ -769,15 +766,14 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
 
 
 class GPUProgrammablePassEncoder(base.GPUProgrammablePassEncoder):
-
     # wgpu.help('BindGroup', 'Index32', 'Size64', 'programmablepassencodersetbindgroup', dev=True)
-    def setBindGroup(
+    def set_bind_group(
         self,
         index,
-        bindGroup,
-        dynamicOffsetsData,
-        dynamicOffsetsDataStart,
-        dynamicOffsetsDataLength,
+        bind_group,
+        dynamic_offsets_data,
+        dynamic_offsets_data_start,
+        dynamic_offsets_data_length,
     ):
         offsets = list(dynamicOffsetsData)
         c_offsets = ffi.new("WGPUBufferAddress []", offsets)
@@ -792,15 +788,15 @@ class GPUProgrammablePassEncoder(base.GPUProgrammablePassEncoder):
             )
 
     # wgpu.help('programmablepassencoderpushdebuggroup', dev=True)
-    def pushDebugGroup(self, groupLabel):
+    def push_debug_group(self, group_label):
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderpopdebuggroup', dev=True)
-    def popDebugGroup(self):
+    def pop_debug_group(self):
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderinsertdebugmarker', dev=True)
-    def insertDebugMarker(self, markerLabel):
+    def insert_debug_marker(self, marker_label):
         raise NotImplementedError()
 
 
@@ -809,7 +805,7 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
     """
 
     # wgpu.help('ComputePipeline', 'computepassencodersetpipeline', dev=True)
-    def setPipeline(self, pipeline):
+    def set_pipeline(self, pipeline):
         pipeline_id = pipeline._internal
         _lib.wgpu_compute_pass_set_pipeline(self._internal, pipeline_id)
 
@@ -818,14 +814,14 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
         _lib.wgpu_compute_pass_dispatch(self._internal, x, y, z)
 
     # wgpu.help('Buffer', 'Size64', 'computepassencoderdispatchindirect', dev=True)
-    def dispatchIndirect(self, indirectBuffer, indirectOffset):
+    def dispatch_indirect(self, indirect_buffer, indirect_offset):
         buffer_id = indirectBuffer._internal
         _lib.wgpu_compute_pass_dispatch_indirect(
             self._internal, buffer_id, indirectOffset
         )
 
     # wgpu.help('computepassencoderendpass', dev=True)
-    def endPass(self):
+    def end_pass(self):
         _lib.wgpu_compute_pass_end_pass(self._internal)
 
 
@@ -834,16 +830,16 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
     """
 
     # wgpu.help('RenderPipeline', 'renderencoderbasesetpipeline', dev=True)
-    def setPipeline(self, pipeline):
+    def set_pipeline(self, pipeline):
         pipeline_id = pipeline._internal
         _lib.wgpu_render_pass_set_pipeline(self._internal, pipeline_id)
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasesetindexbuffer', dev=True)
-    def setIndexBuffer(self, buffer, offset):
+    def set_index_buffer(self, buffer, offset):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Index32', 'Size64', 'renderencoderbasesetvertexbuffer', dev=True)
-    def setVertexBuffer(self, slot, buffer, offset):
+    def set_vertex_buffer(self, slot, buffer, offset):
         buffers, offsets = [buffer], [offset]
         c_buffer_ids = ffi.new("WGPUBufferId []", [b._internal for b in buffers])
         c_offsets = ffi.new("WGPUBufferAddress []", [int(i) for i in offsets])
@@ -852,23 +848,23 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
         )
 
     # wgpu.help('Size32', 'renderencoderbasedraw', dev=True)
-    def draw(self, vertexCount, instanceCount, firstVertex, firstInstance):
+    def draw(self, vertex_count, instance_count, first_vertex, first_instance):
         _lib.wgpu_render_pass_draw(
             self._internal, vertexCount, instanceCount, firstVertex, firstInstance
         )
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindirect', dev=True)
-    def drawIndirect(self, indirectBuffer, indirectOffset):
+    def draw_indirect(self, indirect_buffer, indirect_offset):
         raise NotImplementedError()
 
     # wgpu.help('SignedOffset32', 'Size32', 'renderencoderbasedrawindexed', dev=True)
-    def drawIndexed(
-        self, indexCount, instanceCount, firstIndex, baseVertex, firstInstance
+    def draw_indexed(
+        self, index_count, instance_count, first_index, base_vertex, first_instance
     ):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindexedindirect', dev=True)
-    def drawIndexedIndirect(self, indirectBuffer, indirectOffset):
+    def draw_indexed_indirect(self, indirect_buffer, indirect_offset):
         raise NotImplementedError()
 
 
@@ -881,34 +877,33 @@ class GPURenderPassEncoder(GPURenderEncoderBase):
     """
 
     # wgpu.help('renderpassencodersetviewport', dev=True)
-    def setViewport(self, x, y, width, height, minDepth, maxDepth):
+    def set_viewport(self, x, y, width, height, min_depth, max_depth):
         raise NotImplementedError()
 
     # wgpu.help('IntegerCoordinate', 'renderpassencodersetscissorrect', dev=True)
-    def setScissorRect(self, x, y, width, height):
+    def set_scissor_rect(self, x, y, width, height):
         raise NotImplementedError()
 
     # wgpu.help('Color', 'renderpassencodersetblendcolor', dev=True)
-    def setBlendColor(self, color):
+    def set_blend_color(self, color):
         raise NotImplementedError()
 
     # wgpu.help('StencilValue', 'renderpassencodersetstencilreference', dev=True)
-    def setStencilReference(self, reference):
+    def set_stencil_reference(self, reference):
         raise NotImplementedError()
 
     # wgpu.help('renderpassencoderexecutebundles', dev=True)
-    def executeBundles(self, bundles):
+    def execute_bundles(self, bundles):
         raise NotImplementedError()
 
     # wgpu.help('renderpassencoderendpass', dev=True)
-    def endPass(self):
+    def end_pass(self):
         _lib.wgpu_render_pass_end_pass(self._internal)
 
 
 class GPUQueue(base.GPUQueue):
-
     # wgpu.help('queuesubmit', dev=True)
-    def submit(self, commandBuffers):
+    def submit(self, command_buffers):
         command_buffer_ids = [cb._internal for cb in commandBuffers]
         c_command_buffers = ffi.new("WGPUCommandBufferId []", command_buffer_ids)
         _lib.wgpu_queue_submit(

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -216,7 +216,7 @@ def request_adapter(*, power_preference: "GPUPowerPreference"):
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
 async def request_adapter_async(*, power_preference: "GPUPowerPreference"):
-    """ Async version of ``requestAdapter()``.
+    """ Async version of ``request_adapter()``.
     This function uses the Rust WGPU library.
     """
     return request_adapter(power_preference=power_preference)
@@ -243,7 +243,7 @@ class GPUAdapter(base.GPUAdapter):
         # Fill in defaults of limits
         limits = limits or {}
         limits2 = {}
-        for key in "max_bind_groups":
+        for key in ["max_bind_groups"]:
             limits2[key] = limits.get(key, base.default_limits[key])
 
         extensions = tuple(extensions)
@@ -274,7 +274,7 @@ class GPUAdapter(base.GPUAdapter):
         extensions: "GPUExtensionName-list" = [],
         limits: "GPULimits" = {},
     ):
-        return self.requestDevice(label=label, extensions=extensions, limits=limits)
+        return self.request_device(label=label, extensions=extensions, limits=limits)
 
 
 class GPUDevice(base.GPUDevice):

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -975,12 +975,12 @@ def _copy_docstrings():
             continue
         elif ob.__module__ != __name__:
             continue
-        BaseCls = ob.mro()[1]  # noqa: N806
-        ob.__doc__ = BaseCls.__doc__
+        base_cls = ob.mro()[1]
+        ob.__doc__ = base_cls.__doc__
         for name, attr in ob.__dict__.items():
             if name.startswith("_") or not hasattr(attr, "__doc__"):
                 continue
-            base_attr = getattr(BaseCls, name, None)
+            base_attr = getattr(base_cls, name, None)
             if base_attr is not None:
                 attr.__doc__ = base_attr.__doc__
 

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -176,11 +176,11 @@ def request_adapter(*, power_preference: "GPUPowerPreference"):
     This function uses the Rust WGPU library.
 
     Params:
-        powerPreference(enum): "high-performance" or "low-power"
+        power_preference(enum): "high-performance" or "low-power"
     """
 
     # Convert the descriptor
-    struct = new_struct("WGPURequestAdapterOptions *", power_preference=powerPreference)
+    struct = new_struct("WGPURequestAdapterOptions *", power_preference=power_preference)
 
     # Select possible backends. This is not exposed in the WebGPU API
     # 1 => Backend::Empty,
@@ -217,11 +217,11 @@ async def request_adapter_async(*, power_preference: "GPUPowerPreference"):
     """ Async version of ``requestAdapter()``.
     This function uses the Rust WGPU library.
     """
-    return requestAdapter(powerPreference=powerPreference)
+    return request_adapter(power_preference=power_preference)
 
 
 # Mark as the backend on import time
-_register_backend(requestAdapter, requestAdapterAsync)
+_register_backend(request_adapter, request_adapter_async)
 
 
 class GPUAdapter(base.GPUAdapter):
@@ -242,10 +242,10 @@ class GPUAdapter(base.GPUAdapter):
 
         c_extensions = new_struct(
             "WGPUExtensions *",
-            anisotropic_filtering="anisotropicFiltering" in extensions,
+            anisotropic_filtering="anisotropic_filtering" in extensions,
         )
         c_limits = new_struct(
-            "WGPULimits *", max_bind_groups=limits.get("maxBindGroups", 4)
+            "WGPULimits *", max_bind_groups=limits.get("max_bind_groups", 4)
         )
         struct = new_struct(
             "WGPUDeviceDescriptor *", extensions=c_extensions[0], limits=c_limits[0]
@@ -316,10 +316,10 @@ class GPUDevice(base.GPUDevice):
                 binding=int(binding["binding"]),
                 visibility=int(binding["visibility"]),
                 ty=binding["type"],
-                texture_dimension=binding.get("textureDimension", "2d"),
+                texture_dimension=binding.get("texture_dimension", "2d"),
                 # ???=binding.get("textureComponentType", "float"),
                 multisampled=bool(binding.get("multisampled", False)),
-                dynamic=bool(binding.get("hasDynamicOffset", False)),
+                dynamic=bool(binding.get("has_dynamic_offset", False)),
             )  # WGPUShaderStage
             c_bindings_list.append(c_binding[0])
 
@@ -399,17 +399,17 @@ class GPUDevice(base.GPUDevice):
         self, *, label="", bind_group_layouts: "GPUBindGroupLayout-list"
     ):
 
-        bindGroupLayouts_ids = [x._internal for x in bindGroupLayouts]
+        bind_group_layouts_ids = [x._internal for x in bind_group_layouts]
 
-        c_layout_array = ffi.new("WGPUBindGroupLayoutId []", bindGroupLayouts_ids)
+        c_layout_array = ffi.new("WGPUBindGroupLayoutId []", bind_group_layouts_ids)
         struct = new_struct(
             "WGPUPipelineLayoutDescriptor *",
             bind_group_layouts=c_layout_array,
-            bind_group_layouts_length=len(bindGroupLayouts),
+            bind_group_layouts_length=len(bind_group_layouts),
         )
 
         id = _lib.wgpu_device_create_pipeline_layout(self._internal, struct)
-        return base.GPUPipelineLayout(label, id, self, bindGroupLayouts)
+        return base.GPUPipelineLayout(label, id, self, bind_group_layouts)
 
     # wgpu.help('ShaderModuleDescriptor', 'devicecreateshadermodule', dev=True)
     def create_shader_module(self, *, label="", code: "GPUShaderCode"):
@@ -450,8 +450,8 @@ class GPUDevice(base.GPUDevice):
 
         c_compute_stage = new_struct(
             "WGPUProgrammableStageDescriptor *",
-            module=computeStage["module"]._internal,
-            entry_point=ffi.new("char []", computeStage["entryPoint"].encode()),
+            module=compute_stage["module"]._internal,
+            entry_point=ffi.new("char []", compute_stage["entry_point"].encode()),
         )
 
         struct = new_struct(
@@ -482,62 +482,62 @@ class GPUDevice(base.GPUDevice):
     ):
         c_vertex_stage = new_struct(
             "WGPUProgrammableStageDescriptor *",
-            module=vertexStage["module"]._internal,
-            entry_point=ffi.new("char []", vertexStage["entryPoint"].encode()),
+            module=vertex_stage["module"]._internal,
+            entry_point=ffi.new("char []", vertex_stage["entry_point"].encode()),
         )
         c_fragment_stage = new_struct(
             "WGPUProgrammableStageDescriptor *",
-            module=fragmentStage["module"]._internal,
-            entry_point=ffi.new("char []", fragmentStage["entryPoint"].encode()),
+            module=fragment_stage["module"]._internal,
+            entry_point=ffi.new("char []", fragment_stage["entry_point"].encode()),
         )
         c_rasterization_state = new_struct(
             "WGPURasterizationStateDescriptor *",
-            front_face=rasterizationState["frontFace"],
-            cull_mode=rasterizationState["cullMode"],
-            depth_bias=rasterizationState["depthBias"],
-            depth_bias_slope_scale=rasterizationState["depthBiasSlopeScale"],
-            depth_bias_clamp=rasterizationState["depthBiasClamp"],
+            front_face=rasterization_state["front_face"],
+            cull_mode=rasterization_state["cull_mode"],
+            depth_bias=rasterization_state["depth_bias"],
+            depth_bias_slope_scale=rasterization_state["depth_bias_slope_scale"],
+            depth_bias_clamp=rasterization_state["depth_bias_clamp"],
         )
         c_color_states_list = []
-        for colorState in colorStates:
-            alphaBlend = colorState["alphaBlend"]
-            if not isinstance(alphaBlend, (list, tuple)):  # support dict and tuple
-                alphaBlend = (
-                    alphaBlend["srcFactor"],
-                    alphaBlend["dstFactor"],
-                    alphaBlend["operation"],
+        for color_state in color_states:
+            alpha_blend = color_state["alpha_blend"]
+            if not isinstance(alpha_blend, (list, tuple)):  # support dict and tuple
+                alpha_blend = (
+                    alpha_blend["src_factor"],
+                    alpha_blend["dst_factor"],
+                    alpha_blend["operation"],
                 )
             c_alpha_blend = new_struct(
                 "WGPUBlendDescriptor *",
-                src_factor=alphaBlend[0],
-                dst_factor=alphaBlend[1],
-                operation=alphaBlend[2],
+                src_factor=alpha_blend[0],
+                dst_factor=alpha_blend[1],
+                operation=alpha_blend[2],
             )
-            colorBlend = colorState["colorBlend"]
-            if not isinstance(colorBlend, (list, tuple)):  # support dict and tuple
-                colorBlend = (
-                    colorBlend["srcFactor"],
-                    colorBlend["dstFactor"],
-                    colorBlend["operation"],
+            color_blend = color_state["color_blend"]
+            if not isinstance(color_blend, (list, tuple)):  # support dict and tuple
+                color_blend = (
+                    color_blend["src_factor"],
+                    color_blend["dst_factor"],
+                    color_blend["operation"],
                 )
             c_color_blend = new_struct(
                 "WGPUBlendDescriptor *",
-                src_factor=colorBlend[0],
-                dst_factor=colorBlend[1],
-                operation=colorBlend[2],
+                src_factor=color_blend[0],
+                dst_factor=color_blend[1],
+                operation=color_blend[2],
             )
             c_color_state = new_struct(
                 "WGPUColorStateDescriptor *",
-                format=colorState["format"],
+                format=color_state["format"],
                 alpha_blend=c_alpha_blend[0],
                 color_blend=c_color_blend[0],
-                write_mask=colorState["writeMask"],
+                write_mask=color_state["write_mask"],
             )  # enum
             c_color_states_list.append(c_color_state[0])
         c_color_states_array = ffi.new(
             "WGPUColorStateDescriptor []", c_color_states_list
         )
-        if depthStencilState is None:
+        if depth_stencil_state is None:
             c_depth_stencil_state = ffi.NULL
         else:
             raise NotImplementedError()
@@ -552,14 +552,14 @@ class GPUDevice(base.GPUDevice):
             #     stencil_write_mask
             # )
         c_vertex_buffer_descriptors_list = []
-        for buffer_des in vertexState["vertexBuffers"]:
+        for buffer_des in vertex_state["vertex_buffers"]:
             c_attributes_list = []
             for attribute in buffer_des["attributes"]:
                 c_attribute = new_struct(
                     "WGPUVertexAttributeDescriptor *",
                     format=attribute["format"],
                     offset=attribute["offset"],
-                    shader_location=attribute["shaderLocation"],
+                    shader_location=attribute["shader_location"],
                 )
                 c_attributes_list.append(c_attribute[0])
             c_attributes_array = ffi.new(
@@ -567,7 +567,7 @@ class GPUDevice(base.GPUDevice):
             )
             c_vertex_buffer_descriptor = new_struct(
                 "WGPUVertexBufferDescriptor *",
-                stride=buffer_des["arrayStride"],
+                stride=buffer_des["array_stride"],
                 step_mode=buffer_des["stepmode"],
                 attributes=c_attributes_array,
                 attributes_length=len(c_attributes_list),
@@ -578,7 +578,7 @@ class GPUDevice(base.GPUDevice):
         )
         c_vertex_input = new_struct(
             "WGPUVertexInputDescriptor *",
-            index_format=vertexState["indexFormat"],
+            index_format=vertex_state["index_format"],
             vertex_buffers=c_vertex_buffer_descriptors_array,
             vertex_buffers_length=len(c_vertex_buffer_descriptors_list),
         )
@@ -588,15 +588,15 @@ class GPUDevice(base.GPUDevice):
             layout=layout._internal,
             vertex_stage=c_vertex_stage[0],
             fragment_stage=c_fragment_stage,
-            primitive_topology=primitiveTopology,
+            primitive_topology=primitive_topology,
             rasterization_state=c_rasterization_state,
             color_states=c_color_states_array,
             color_states_length=len(c_color_states_list),
             depth_stencil_state=c_depth_stencil_state,
             vertex_input=c_vertex_input[0],
-            sample_count=sampleCount,
-            sample_mask=sampleMask,
-            alpha_to_coverage_enabled=alphaToCoverageEnabled,
+            sample_count=sample_count,
+            sample_mask=sample_mask,
+            alpha_to_coverage_enabled=alpha_to_coverage_enabled,
         )  # c-pointer  # enum
 
         id = _lib.wgpu_device_create_render_pipeline(self._internal, struct)
@@ -610,7 +610,7 @@ class GPUDevice(base.GPUDevice):
         id = _lib.wgpu_device_create_command_encoder(self._internal, struct)
         return GPUCommandEncoder(label, id, self)
 
-    def _gui_configureSwapChain(self, canvas, format, usage):
+    def _gui_configure_swap_chain(self, canvas, format, usage):
         """ Get a swapchain object from a canvas object. Called by BaseCanvas.
         """
         # Note: canvas should implement the BaseCanvas interface.
@@ -680,10 +680,10 @@ class GPUTexture(base.GPUTexture):
             "WGPUTextureViewDescriptor *",
             dimension=dimension,
             aspect=aspect,
-            base_mip_level=baseMipLevel,
-            level_count=mipLevelCount,
-            base_array_layer=baseArrayLayer,
-            array_layer_count=arrayLayerCount,
+            base_mip_level=base_mip_level,
+            level_count=mip_level_count,
+            base_array_layer=base_array_layer,
+            array_layer_count=array_layer_count,
         )
 
         id = _lib.wgpu_texture_create_view(self._internal, struct)
@@ -711,20 +711,20 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
     ):
 
         c_color_attachments_list = []
-        for colorAttachment in colorAttachments:
-            assert isinstance(colorAttachment["attachment"], base.GPUTextureView)
-            texture_view_id = colorAttachment["attachment"]._internal
-            if colorAttachment["resolveTarget"] is None:
+        for color_attachment in color_attachments:
+            assert isinstance(color_attachment["attachment"], base.GPUTextureView)
+            texture_view_id = color_attachment["attachment"]._internal
+            if color_attachment["resolve_target"] is None:
                 c_resolve_target = ffi.NULL
             else:
                 raise NotImplementedError()
-            if isinstance(colorAttachment["loadValue"], str):
-                assert colorAttachment["loadValue"] == "load"
+            if isinstance(color_attachment["load_value"], str):
+                assert color_attachment["load_value"] == "load"
                 c_load_op = 1  # WGPULoadOp_Load
                 c_clear_color = ffi.new("WGPUColor *", dict(r=0, g=0, b=0, a=0))
             else:
                 c_load_op = 0  # WGPULoadOp_Clear
-                clr = colorAttachment["loadValue"]
+                clr = color_attachment["load_value"]
                 if isinstance(clr, dict):
                     c_clear_color = ffi.new("WGPUColor *", *clr)
                 else:
@@ -736,7 +736,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
                 attachment=texture_view_id,
                 resolve_target=c_resolve_target,
                 load_op=c_load_op,
-                store_op=colorAttachment["storeOp"],
+                store_op=color_attachment["store_op"],
                 clear_color=c_clear_color[0],
             )
             c_color_attachments_list.append(c_attachment[0])
@@ -745,7 +745,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
         )
 
         c_depth_stencil_attachment = ffi.NULL
-        if depthStencilAttachment is not None:
+        if depth_stencil_attachment is not None:
             raise NotImplementedError()
 
         struct = new_struct(
@@ -775,9 +775,9 @@ class GPUProgrammablePassEncoder(base.GPUProgrammablePassEncoder):
         dynamic_offsets_data_start,
         dynamic_offsets_data_length,
     ):
-        offsets = list(dynamicOffsetsData)
+        offsets = list(dynamic_offsets_data)
         c_offsets = ffi.new("WGPUBufferAddress []", offsets)
-        bind_group_id = bindGroup._internal
+        bind_group_id = bind_group._internal
         if isinstance(self, GPUComputePassEncoder):
             _lib.wgpu_compute_pass_set_bind_group(
                 self._internal, index, bind_group_id, c_offsets, len(offsets)
@@ -815,9 +815,9 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
 
     # wgpu.help('Buffer', 'Size64', 'computepassencoderdispatchindirect', dev=True)
     def dispatch_indirect(self, indirect_buffer, indirect_offset):
-        buffer_id = indirectBuffer._internal
+        buffer_id = indirect_buffer._internal
         _lib.wgpu_compute_pass_dispatch_indirect(
-            self._internal, buffer_id, indirectOffset
+            self._internal, buffer_id, indirect_offset
         )
 
     # wgpu.help('computepassencoderendpass', dev=True)
@@ -850,7 +850,7 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
     # wgpu.help('Size32', 'renderencoderbasedraw', dev=True)
     def draw(self, vertex_count, instance_count, first_vertex, first_instance):
         _lib.wgpu_render_pass_draw(
-            self._internal, vertexCount, instanceCount, firstVertex, firstInstance
+            self._internal, vertex_count, instance_count, first_vertex, first_instance
         )
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindirect', dev=True)
@@ -904,7 +904,7 @@ class GPURenderPassEncoder(GPURenderEncoderBase):
 class GPUQueue(base.GPUQueue):
     # wgpu.help('queuesubmit', dev=True)
     def submit(self, command_buffers):
-        command_buffer_ids = [cb._internal for cb in commandBuffers]
+        command_buffer_ids = [cb._internal for cb in command_buffers]
         c_command_buffers = ffi.new("WGPUCommandBufferId []", command_buffer_ids)
         _lib.wgpu_queue_submit(
             self._internal, c_command_buffers, len(command_buffer_ids)
@@ -919,9 +919,9 @@ class GPUSwapChain(base.GPUSwapChain):
         self._usage = usage
         self._surface_size = (-1, -1)
         self._surface_id = None
-        self._create_native_swapchain_if_needed()
+        self._create_native_swap_chain_if_needed()
 
-    def _create_native_swapchain_if_needed(self):
+    def _create_native_swap_chain_if_needed(self):
         cur_size = self._canvas.getSizeAndPixelRatio()  # width, height, ratio
         if cur_size == self._surface_size:
             return
@@ -944,12 +944,12 @@ class GPUSwapChain(base.GPUSwapChain):
             self._device._internal, self._surface_id, struct
         )  # device-id
 
-    def getCurrentTextureView(self):
+    def get_current_texture_view(self):
         # todo: should we cache instances (on their id)?
         # otherwise we have multiple instances mapping to same internal texture
-        self._create_native_swapchain_if_needed()
-        swapChainOutput = _lib.wgpu_swap_chain_get_next_texture(self._internal)
-        return base.GPUTextureView("swapchain", swapChainOutput.view_id, self)
+        self._create_native_swap_chain_if_needed()
+        swap_chain_output = _lib.wgpu_swap_chain_get_next_texture(self._internal)
+        return base.GPUTextureView("swap_chain", swap_chain_output.view_id, self)
 
     def _gui_present(self):
         """ Present the current texture. This is not part of the public API,
@@ -967,7 +967,7 @@ def _copy_docstrings():
             continue
         elif ob.__module__ != __name__:
             continue
-        BaseCls = ob.mro()[1]
+        BaseCls = ob.mro()[1]  # noqa: N806
         ob.__doc__ = BaseCls.__doc__
         for name, attr in ob.__dict__.items():
             if name.startswith("_") or not hasattr(attr, "__doc__"):

--- a/wgpu/backend/rs.py
+++ b/wgpu/backend/rs.py
@@ -240,6 +240,12 @@ class GPUAdapter(base.GPUAdapter):
         limits: "GPULimits" = {},
     ):
 
+        # Fill in defaults of limits
+        limits = limits or {}
+        limits2 = {}
+        for key in "max_bind_groups":
+            limits2[key] = limits.get(key, base.default_limits[key])
+
         extensions = tuple(extensions)
 
         c_extensions = new_struct(
@@ -247,7 +253,7 @@ class GPUAdapter(base.GPUAdapter):
             anisotropic_filtering="anisotropic_filtering" in extensions,
         )
         c_limits = new_struct(
-            "WGPULimits *", max_bind_groups=limits.get("max_bind_groups", 4)
+            "WGPULimits *", max_bind_groups=limits2["max_bind_groups"]
         )
         struct = new_struct(
             "WGPUDeviceDescriptor *", extensions=c_extensions[0], limits=c_limits[0]
@@ -258,7 +264,7 @@ class GPUAdapter(base.GPUAdapter):
         queue_id = _lib.wgpu_device_get_queue(id)
         queue = GPUQueue("", queue_id, self)
 
-        return GPUDevice(label, id, self, extensions, limits, queue)
+        return GPUDevice(label, id, self, extensions, limits2, queue)
 
     # wgpu.help('DeviceDescriptor', 'adapterrequestdevice', dev=True)
     async def request_device_async(

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -147,13 +147,13 @@ class GPUDevice(GPUObject):
     invalid.
     """
 
-    def __init__(self, label, internal, adapter, extensions, limits, defaul_queue):
+    def __init__(self, label, internal, adapter, extensions, limits, default_queue):
         super().__init__(label, internal, None)
         assert isinstance(adapter, GPUAdapter)
         self._adapter = adapter
         self._extensions = extensions
         self._limits = limits
-        self._defaul_queue = defaul_queue
+        self._default_queue = default_queue
 
     @property
     def extensions(self):
@@ -164,15 +164,15 @@ class GPUDevice(GPUObject):
 
     @property
     def limits(self):
-        """ A GPULimits object exposing the limits with which this device was created.
+        """ A dict exposing the limits with which this device was created.
         """
         return self._limits
 
     @property
-    def defaul_queue(self):
+    def default_queue(self):
         """ The default queue for this device.
         """
-        return self._defaul_queue
+        return self._default_queue
 
     # wgpu.help('BufferDescriptor', 'devicecreatebuffer', dev=True)
     # IDL: GPUBuffer createBuffer(GPUBufferDescriptor descriptor);

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -17,7 +17,7 @@ Developer notes and tips:
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
 # IDL: Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
-def requestAdapter(*, powerPreference: "GPUPowerPreference"):
+def request_adapter(*, power_preference: "GPUPowerPreference"):
     """ Request an Adapter, the object that represents the implementation of WGPU.
     Before requesting an adapter, a wgpu backend should be selected. At the moment
     there is only one backend. Use ``import wgpu.rs`` to select it.
@@ -32,8 +32,8 @@ def requestAdapter(*, powerPreference: "GPUPowerPreference"):
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
 # IDL: Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
-async def requestAdapterAsync(*, powerPreference: "GPUPowerPreference"):
-    """ Async version of ``requestAdapter()``.
+async def request_adapter_async(*, power_preference: "GPUPowerPreference"):
+    """ Async version of ``request_adapter()``.
     """
     raise RuntimeError(
         "Select a backend (by importing wgpu.rs) before requesting an adapter!"
@@ -96,7 +96,7 @@ class GPUAdapter:  # Not a GPUObject
 
     # wgpu.help('DeviceDescriptor', 'adapterrequestdevice', dev=True)
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    def requestDevice(
+    def request_device(
         self,
         *,
         label="",
@@ -113,14 +113,14 @@ class GPUAdapter:  # Not a GPUObject
 
     # wgpu.help('DeviceDescriptor', 'adapterrequestdevice', dev=True)
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    async def requestDeviceAsync(
+    async def request_device_async(
         self,
         *,
         label="",
         extensions: "GPUExtensionName-list" = [],
         limits: "GPULimits" = {},
     ):
-        """ Async version of requestDevice().
+        """ Async version of request_device().
         """
         raise NotImplementedError()
 
@@ -165,13 +165,13 @@ class GPUDevice(GPUObject):
     invalid.
     """
 
-    def __init__(self, label, internal, adapter, extensions, limits, defaultQueue):
+    def __init__(self, label, internal, adapter, extensions, limits, defaul_queue):
         super().__init__(label, internal, None)
         assert isinstance(adapter, GPUAdapter)
         self._adapter = adapter
         self._extensions = extensions
         self._limits = limits
-        self._defaultQueue = defaultQueue
+        self._defaul_queue = defaul_queue
 
     @property
     def extensions(self):
@@ -187,14 +187,14 @@ class GPUDevice(GPUObject):
         return self._limits
 
     @property
-    def defaultQueue(self):
+    def defaul_queue(self):
         """ The default queue for this device.
         """
-        return self._defaultQueue
+        return self._defaul_queue
 
     # wgpu.help('BufferDescriptor', 'devicecreatebuffer', dev=True)
     # IDL: GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
-    def createBuffer(
+    def create_buffer(
         self, *, label="", size: "GPUSize64", usage: "GPUBufferUsageFlags"
     ):
         """ Create a Buffer object.
@@ -203,7 +203,7 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('BufferDescriptor', 'devicecreatebuffermapped', dev=True)
     # IDL: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
-    def createBufferMapped(
+    def create_buffer_mapped(
         self, *, label="", size: "GPUSize64", usage: "GPUBufferUsageFlags"
     ):
         """ Create a mapped buffer object (its memory is accesable to the CPU).
@@ -212,7 +212,7 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('BufferDescriptor', 'devicecreatebuffermapped', dev=True)
     # IDL: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
-    async def createBufferMappedAsync(
+    async def create_buffer_mapped_async(
         self, *, label="", size: "GPUSize64", usage: "GPUBufferUsageFlags"
     ):
         """ Asynchronously create a mapped buffer object.
@@ -221,14 +221,14 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('TextureDescriptor', 'devicecreatetexture', dev=True)
     # IDL: GPUTexture createTexture(GPUTextureDescriptor descriptor);
-    def createTexture(
+    def create_texture(
         self,
         *,
         label="",
         size: "GPUExtent3D",
-        arrayLayerCount: "GPUIntegerCoordinate" = 1,
-        mipLevelCount: "GPUIntegerCoordinate" = 1,
-        sampleCount: "GPUSize32" = 1,
+        array_layer_count: "GPUIntegerCoordinate" = 1,
+        mip_level_count: "GPUIntegerCoordinate" = 1,
+        sample_count: "GPUSize32" = 1,
         dimension: "GPUTextureDimension" = "2d",
         format: "GPUTextureFormat",
         usage: "GPUTextureUsageFlags",
@@ -239,18 +239,18 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('SamplerDescriptor', 'devicecreatesampler', dev=True)
     # IDL: GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
-    def createSampler(
+    def create_sampler(
         self,
         *,
         label="",
-        addressModeU: "GPUAddressMode" = "clamp-to-edge",
-        addressModeV: "GPUAddressMode" = "clamp-to-edge",
-        addressModeW: "GPUAddressMode" = "clamp-to-edge",
-        magFilter: "GPUFilterMode" = "nearest",
-        minFilter: "GPUFilterMode" = "nearest",
-        mipmapFilter: "GPUFilterMode" = "nearest",
-        lodMinClamp: float = 0,
-        lodMaxClamp: float = 0xFFFFFFFF,
+        address_mode_u: "GPUAddressMode" = "clamp-to-edge",
+        address_mode_v: "GPUAddressMode" = "clamp-to-edge",
+        address_mode_w: "GPUAddressMode" = "clamp-to-edge",
+        mag_filter: "GPUFilterMode" = "nearest",
+        min_filter: "GPUFilterMode" = "nearest",
+        mipmap_filter: "GPUFilterMode" = "nearest",
+        lod_min_clamp: float = 0,
+        lod_max_clamp: float = 0xFFFFFFFF,
         compare: "GPUCompareFunction" = "never",
     ):
         """ Create a Sampler object. Use des (SamplerDescriptor) to specify its modes.
@@ -259,7 +259,7 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('BindGroupLayoutDescriptor', 'devicecreatebindgrouplayout', dev=True)
     # IDL: GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
-    def createBindGroupLayout(
+    def create_bind_group_layout(
         self, *, label="", bindings: "GPUBindGroupLayoutBinding-list"
     ):
         """ Create a GPUBindGroupLayout.
@@ -289,7 +289,7 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('BindGroupDescriptor', 'devicecreatebindgroup', dev=True)
     # IDL: GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor);
-    def createBindGroup(
+    def create_bind_group(
         self,
         *,
         label="",
@@ -303,8 +303,8 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('PipelineLayoutDescriptor', 'devicecreatepipelinelayout', dev=True)
     # IDL: GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);
-    def createPipelineLayout(
-        self, *, label="", bindGroupLayouts: "GPUBindGroupLayout-list"
+    def create_pipeline_layout(
+        self, *, label="", bind_group_layouts: "GPUBindGroupLayout-list"
     ):
         """ Create a GPUPipelineLayout, consisting of a list of GPUBindGroupLayout
         objects.
@@ -313,37 +313,37 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('ShaderModuleDescriptor', 'devicecreateshadermodule', dev=True)
     # IDL: GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
-    def createShaderModule(self, *, label="", code: "GPUShaderCode"):
+    def create_shader_module(self, *, label="", code: "GPUShaderCode"):
         raise NotImplementedError()
 
     # wgpu.help('ComputePipelineDescriptor', 'devicecreatecomputepipeline', dev=True)
     # IDL: GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
-    def createComputePipeline(
+    def create_compute_pipeline(
         self,
         *,
         label="",
         layout: "GPUPipelineLayout",
-        computeStage: "GPUProgrammableStageDescriptor",
+        compute_stage: "GPUProgrammableStageDescriptor",
     ):
         raise NotImplementedError()
 
     # wgpu.help('RenderPipelineDescriptor', 'devicecreaterenderpipeline', dev=True)
     # IDL: GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
-    def createRenderPipeline(
+    def create_render_pipeline(
         self,
         *,
         label="",
         layout: "GPUPipelineLayout",
-        vertexStage: "GPUProgrammableStageDescriptor",
-        fragmentStage: "GPUProgrammableStageDescriptor",
-        primitiveTopology: "GPUPrimitiveTopology",
-        rasterizationState: "GPURasterizationStateDescriptor" = {},
-        colorStates: "GPUColorStateDescriptor-list",
-        depthStencilState: "GPUDepthStencilStateDescriptor",
-        vertexState: "GPUVertexStateDescriptor" = {},
-        sampleCount: "GPUSize32" = 1,
-        sampleMask: "GPUSampleMask" = 0xFFFFFFFF,
-        alphaToCoverageEnabled: bool = False,
+        vertex_stage: "GPUProgrammableStageDescriptor",
+        fragment_stage: "GPUProgrammableStageDescriptor",
+        primitive_topology: "GPUPrimitiveTopology",
+        rasterization_state: "GPURasterizationStateDescriptor" = {},
+        color_states: "GPUColorStateDescriptor-list",
+        depth_stencil_state: "GPUDepthStencilStateDescriptor",
+        vertex_state: "GPUVertexStateDescriptor" = {},
+        sample_count: "GPUSize32" = 1,
+        sample_mask: "GPUSampleMask" = 0xFFFFFFFF,
+        alpha_to_coverage_enabled: bool = False,
     ):
         """ Create a GPURenderPipeline object describing a render pipeline.
 
@@ -385,18 +385,18 @@ class GPUDevice(GPUObject):
 
     # wgpu.help('CommandEncoderDescriptor', 'devicecreatecommandencoder', dev=True)
     # IDL: GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
-    def createCommandEncoder(self, *, label=""):
+    def create_command_encoder(self, *, label=""):
         raise NotImplementedError()
 
     # wgpu.help('RenderBundleEncoderDescriptor', 'devicecreaterenderbundleencoder', dev=True)
     # IDL: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
-    def createRenderBundleEncoder(
+    def create_render_bundle_encoder(
         self,
         *,
         label="",
-        colorFormats: "GPUTextureFormat-list",
-        depthStencilFormat: "GPUTextureFormat",
-        sampleCount: "GPUSize32" = 1,
+        color_formats: "GPUTextureFormat-list",
+        depth_stencil_format: "GPUTextureFormat",
+        sample_count: "GPUSize32" = 1,
     ):
         raise NotImplementedError()
 
@@ -464,22 +464,22 @@ class GPUBuffer(GPUObject):
 
     # wgpu.help('buffermapreadasync', dev=True)
     # IDL: Promise<ArrayBuffer> mapReadAsync();
-    def mapRead(self):
+    def map_read(self):
         raise NotImplementedError()
 
     # wgpu.help('buffermapreadasync', dev=True)
     # IDL: Promise<ArrayBuffer> mapReadAsync();
-    async def mapReadAsync(self):
+    async def map_read_async(self):
         raise NotImplementedError()
 
     # wgpu.help('buffermapwriteasync', dev=True)
     # IDL: Promise<ArrayBuffer> mapWriteAsync();
-    def mapWrite(self):
+    def map_write(self):
         raise NotImplementedError()
 
     # wgpu.help('buffermapwriteasync', dev=True)
     # IDL: Promise<ArrayBuffer> mapWriteAsync();
-    async def mapWriteAsync(self):
+    async def map_write_async(self):
         raise NotImplementedError()
 
     # wgpu.help('bufferunmap', dev=True)
@@ -503,17 +503,17 @@ class GPUTexture(GPUObject):
 
     # wgpu.help('TextureViewDescriptor', 'texturecreateview', dev=True)
     # IDL: GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
-    def createView(
+    def create_view(
         self,
         *,
         label="",
         format: "GPUTextureFormat",
         dimension: "GPUTextureViewDimension",
         aspect: "GPUTextureAspect" = "all",
-        baseMipLevel: "GPUIntegerCoordinate" = 0,
-        mipLevelCount: "GPUIntegerCoordinate" = 0,
-        baseArrayLayer: "GPUIntegerCoordinate" = 0,
-        arrayLayerCount: "GPUIntegerCoordinate" = 0,
+        base_mip_level: "GPUIntegerCoordinate" = 0,
+        mip_level_count: "GPUIntegerCoordinate" = 0,
+        base_array_layer: "GPUIntegerCoordinate" = 0,
+        array_layer_count: "GPUIntegerCoordinate" = 0,
     ):
         raise NotImplementedError()
 
@@ -594,55 +594,55 @@ class GPUCommandEncoder(GPUObject):
 
     # wgpu.help('ComputePassDescriptor', 'commandencoderbegincomputepass', dev=True)
     # IDL: GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
-    def beginComputePass(self, *, label=""):
+    def begin_compute_pass(self, *, label=""):
         raise NotImplementedError()
 
     # wgpu.help('RenderPassDescriptor', 'commandencoderbeginrenderpass', dev=True)
     # IDL: GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
-    def beginRenderPass(
+    def begin_render_pass(
         self,
         *,
         label="",
-        colorAttachments: "GPURenderPassColorAttachmentDescriptor-list",
-        depthStencilAttachment: "GPURenderPassDepthStencilAttachmentDescriptor",
+        color_attachments: "GPURenderPassColorAttachmentDescriptor-list",
+        depth_stencil_attachment: "GPURenderPassDepthStencilAttachmentDescriptor",
     ):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Size64', 'commandencodercopybuffertobuffer', dev=True)
     # IDL: void copyBufferToBuffer( GPUBuffer source, GPUSize64 sourceOffset, GPUBuffer destination, GPUSize64 destinationOffset, GPUSize64 size);
-    def copyBufferToBuffer(
-        self, source, sourceOffset, destination, destinationOffset, size
+    def copy_buffer_to_buffer(
+        self, source, source_offset, destination, destination_offset, size
     ):
         raise NotImplementedError()
 
     # wgpu.help('BufferCopyView', 'Extent3D', 'TextureCopyView', 'commandencodercopybuffertotexture', dev=True)
     # IDL: void copyBufferToTexture( GPUBufferCopyView source, GPUTextureCopyView destination, GPUExtent3D copySize);
-    def copyBufferToTexture(self, source, destination, copySize):
+    def copy_buffer_to_texture(self, source, destination, copy_size):
         raise NotImplementedError()
 
     # wgpu.help('BufferCopyView', 'Extent3D', 'TextureCopyView', 'commandencodercopytexturetobuffer', dev=True)
     # IDL: void copyTextureToBuffer( GPUTextureCopyView source, GPUBufferCopyView destination, GPUExtent3D copySize);
-    def copyTextureToBuffer(self, source, destination, copySize):
+    def copy_texture_to_buffer(self, source, destination, copy_size):
         raise NotImplementedError()
 
     # wgpu.help('Extent3D', 'TextureCopyView', 'commandencodercopytexturetotexture', dev=True)
     # IDL: void copyTextureToTexture( GPUTextureCopyView source, GPUTextureCopyView destination, GPUExtent3D copySize);
-    def copyTextureToTexture(self, source, destination, copySize):
+    def copy_texture_to_texture(self, source, destination, copy_size):
         raise NotImplementedError()
 
     # wgpu.help('commandencoderpushdebuggroup', dev=True)
     # IDL: void pushDebugGroup(DOMString groupLabel);
-    def pushDebugGroup(self, groupLabel):
+    def push_debug_group(self, group_label):
         raise NotImplementedError()
 
     # wgpu.help('commandencoderpopdebuggroup', dev=True)
     # IDL: void popDebugGroup();
-    def popDebugGroup(self):
+    def pop_debug_group(self):
         raise NotImplementedError()
 
     # wgpu.help('commandencoderinsertdebugmarker', dev=True)
     # IDL: void insertDebugMarker(DOMString markerLabel);
-    def insertDebugMarker(self, markerLabel):
+    def insert_debug_marker(self, marker_label):
         raise NotImplementedError()
 
     # wgpu.help('CommandBufferDescriptor', 'commandencoderfinish', dev=True)
@@ -652,32 +652,31 @@ class GPUCommandEncoder(GPUObject):
 
 
 class GPUProgrammablePassEncoder(GPUObject):
-
     # wgpu.help('BindGroup', 'Index32', 'Size64', 'programmablepassencodersetbindgroup', dev=True)
     # IDL: void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,  Uint32Array dynamicOffsetsData,  GPUSize64 dynamicOffsetsDataStart,  GPUSize64 dynamicOffsetsDataLength);
-    def setBindGroup(
+    def set_bind_group(
         self,
         index,
-        bindGroup,
-        dynamicOffsetsData,
-        dynamicOffsetsDataStart,
-        dynamicOffsetsDataLength,
+        bind_group,
+        dynamic_offsets_data,
+        dynamic_offsets_data_start,
+        dynamic_offsets_data_length,
     ):
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderpushdebuggroup', dev=True)
     # IDL: void pushDebugGroup(DOMString groupLabel);
-    def pushDebugGroup(self, groupLabel):
+    def push_debug_group(self, group_label):
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderpopdebuggroup', dev=True)
     # IDL: void popDebugGroup();
-    def popDebugGroup(self):
+    def pop_debug_group(self):
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderinsertdebugmarker', dev=True)
     # IDL: void insertDebugMarker(DOMString markerLabel);
-    def insertDebugMarker(self, markerLabel):
+    def insert_debug_marker(self, marker_label):
         raise NotImplementedError()
 
 
@@ -687,7 +686,7 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
 
     # wgpu.help('ComputePipeline', 'computepassencodersetpipeline', dev=True)
     # IDL: void setPipeline(GPUComputePipeline pipeline);
-    def setPipeline(self, pipeline):
+    def set_pipeline(self, pipeline):
         raise NotImplementedError()
 
     # wgpu.help('Size32', 'computepassencoderdispatch', dev=True)
@@ -697,12 +696,12 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
 
     # wgpu.help('Buffer', 'Size64', 'computepassencoderdispatchindirect', dev=True)
     # IDL: void dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    def dispatchIndirect(self, indirectBuffer, indirectOffset):
+    def dispatch_indirect(self, indirect_buffer, indirect_offset):
         raise NotImplementedError()
 
     # wgpu.help('computepassencoderendpass', dev=True)
     # IDL: void endPass();
-    def endPass(self):
+    def end_pass(self):
         raise NotImplementedError()
 
 
@@ -712,39 +711,39 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
 
     # wgpu.help('RenderPipeline', 'renderencoderbasesetpipeline', dev=True)
     # IDL: void setPipeline(GPURenderPipeline pipeline);
-    def setPipeline(self, pipeline):
+    def set_pipeline(self, pipeline):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasesetindexbuffer', dev=True)
     # IDL: void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0);
-    def setIndexBuffer(self, buffer, offset):
+    def set_index_buffer(self, buffer, offset):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Index32', 'Size64', 'renderencoderbasesetvertexbuffer', dev=True)
     # IDL: void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0);
-    def setVertexBuffer(self, slot, buffer, offset):
+    def set_vertex_buffer(self, slot, buffer, offset):
         raise NotImplementedError()
 
     # wgpu.help('Size32', 'renderencoderbasedraw', dev=True)
     # IDL: void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,  GPUSize32 firstVertex, GPUSize32 firstInstance);
-    def draw(self, vertexCount, instanceCount, firstVertex, firstInstance):
+    def draw(self, vertex_count, instance_count, first_vertex, first_instance):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindirect', dev=True)
     # IDL: void drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    def drawIndirect(self, indirectBuffer, indirectOffset):
+    def draw_indirect(self, indirect_buffer, indirect_offset):
         raise NotImplementedError()
 
     # wgpu.help('SignedOffset32', 'Size32', 'renderencoderbasedrawindexed', dev=True)
     # IDL: void drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,  GPUSize32 firstIndex, GPUSignedOffset32 baseVertex, GPUSize32 firstInstance);
-    def drawIndexed(
-        self, indexCount, instanceCount, firstIndex, baseVertex, firstInstance
+    def draw_indexed(
+        self, index_count, instance_count, first_index, base_vertex, first_instance
     ):
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindexedindirect', dev=True)
     # IDL: void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    def drawIndexedIndirect(self, indirectBuffer, indirectOffset):
+    def draw_indexed_indirect(self, indirect_buffer, indirect_offset):
         raise NotImplementedError()
 
 
@@ -754,32 +753,32 @@ class GPURenderPassEncoder(GPURenderEncoderBase):
 
     # wgpu.help('renderpassencodersetviewport', dev=True)
     # IDL: void setViewport(float x, float y,  float width, float height,  float minDepth, float maxDepth);
-    def setViewport(self, x, y, width, height, minDepth, maxDepth):
+    def set_viewport(self, x, y, width, height, min_depth, max_depth):
         raise NotImplementedError()
 
     # wgpu.help('IntegerCoordinate', 'renderpassencodersetscissorrect', dev=True)
     # IDL: void setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,  GPUIntegerCoordinate width, GPUIntegerCoordinate height);
-    def setScissorRect(self, x, y, width, height):
+    def set_scissor_rect(self, x, y, width, height):
         raise NotImplementedError()
 
     # wgpu.help('Color', 'renderpassencodersetblendcolor', dev=True)
     # IDL: void setBlendColor(GPUColor color);
-    def setBlendColor(self, color):
+    def set_blend_color(self, color):
         raise NotImplementedError()
 
     # wgpu.help('StencilValue', 'renderpassencodersetstencilreference', dev=True)
     # IDL: void setStencilReference(GPUStencilValue reference);
-    def setStencilReference(self, reference):
+    def set_stencil_reference(self, reference):
         raise NotImplementedError()
 
     # wgpu.help('renderpassencoderexecutebundles', dev=True)
     # IDL: void executeBundles(sequence<GPURenderBundle> bundles);
-    def executeBundles(self, bundles):
+    def execute_bundles(self, bundles):
         raise NotImplementedError()
 
     # wgpu.help('renderpassencoderendpass', dev=True)
     # IDL: void endPass();
-    def endPass(self):
+    def end_pass(self):
         raise NotImplementedError()
 
 
@@ -799,15 +798,14 @@ class GPURenderBundleEncoder(GPURenderEncoderBase):
 
 
 class GPUQueue(GPUObject):
-
     # wgpu.help('queuesubmit', dev=True)
     # IDL: void submit(sequence<GPUCommandBuffer> commandBuffers);
-    def submit(self, commandBuffers):
+    def submit(self, command_buffers):
         raise NotImplementedError()
 
     # wgpu.help('Extent3D', 'ImageBitmapCopyView', 'TextureCopyView', 'queuecopyimagebitmaptotexture', dev=True)
     # IDL: void copyImageBitmapToTexture( GPUImageBitmapCopyView source, GPUTextureCopyView destination, GPUExtent3D copySize);
-    def copyImageBitmapToTexture(self, source, destination, copySize):
+    def copy_image_bitmap_to_texture(self, source, destination, copy_size):
         raise NotImplementedError()
 
 
@@ -817,7 +815,7 @@ class GPUSwapChain(GPUObject):
 
     # wgpu.help('swapchaingetcurrenttexture', dev=True)
     # IDL: GPUTexture getCurrentTexture();
-    def getCurrentTexture(self):
+    def get_current_texture(self):
         """ For now, use getCurrentTextureView.
         """
         raise NotImplementedError("Use getCurrentTextureView() instead for now")

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -18,7 +18,7 @@ Developer notes and tips:
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
 # IDL: Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
 def request_adapter(*, power_preference: "GPUPowerPreference"):
-    """ Request an Adapter, the object that represents the implementation of WGPU.
+    """ Request a GPUAdapter, the object that represents the implementation of WGPU.
     Before requesting an adapter, a wgpu backend should be selected. At the moment
     there is only one backend. Use ``import wgpu.rs`` to select it.
 
@@ -400,8 +400,8 @@ class GPUDevice(GPUObject):
     ):
         raise NotImplementedError()
 
-    def _gui_configureSwapChain(self, canvas, format, usage):
-        """ Get a swapchain object from a canvas object. Called by BaseCanvas.
+    def _gui_configure_swap_chain(self, canvas, format, usage):
+        """ Get a SwapChain object from a canvas object. Called by BaseCanvas.
         """
         raise NotImplementedError()
 
@@ -816,11 +816,11 @@ class GPUSwapChain(GPUObject):
     # wgpu.help('swapchaingetcurrenttexture', dev=True)
     # IDL: GPUTexture getCurrentTexture();
     def get_current_texture(self):
-        """ For now, use getCurrentTextureView.
+        """ For now, use get_current_texture_view.
         """
-        raise NotImplementedError("Use getCurrentTextureView() instead for now")
+        raise NotImplementedError("Use get_current_texture_view() instead for now")
 
-    def getCurrentTextureView(self):
+    def get_current_texture_view(self):
         """ NOTICE: this function is likely to change or be replaced by
         getCurrentTexture() at some point. An incompatibility between wgpu-native and
         WebGPU requires us to implement this workaround.

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -125,34 +125,16 @@ class GPUAdapter:  # Not a GPUObject
         raise NotImplementedError()
 
 
-class GPULimits(DictLike):
-    """ A dict-like object representing the device limits.
-    """
-
-    def __init__(
-        self,
-        *,
-        maxBindGroups=4,
-        maxDynamicUniformBuffersPerPipelineLayout=8,
-        maxDynamicStorageBuffersPerPipelineLayout=4,
-        maxSampledTexturesPerShaderStage=16,
-        maxSamplersPerShaderStage=16,
-        maxStorageBuffersPerShaderStage=4,
-        maxStorageTexturesPerShaderStage=4,
-        maxUniformBuffersPerShaderStage=12,
-    ):
-        self.maxBindGroups = maxBindGroups
-        self.maxDynamicUniformBuffersPerPipelineLayout = (
-            maxDynamicUniformBuffersPerPipelineLayout
-        )
-        self.maxDynamicStorageBuffersPerPipelineLayout = (
-            maxDynamicStorageBuffersPerPipelineLayout
-        )
-        self.maxSampledTexturesPerShaderStage = maxSampledTexturesPerShaderStage
-        self.maxSamplersPerShaderStage = maxSamplersPerShaderStage
-        self.maxStorageBuffersPerShaderStage = maxStorageBuffersPerShaderStage
-        self.maxStorageTexturesPerShaderStage = maxStorageTexturesPerShaderStage
-        self.maxUniformBuffersPerShaderStage = (maxUniformBuffersPerShaderStage,)
+default_limits = dict(
+    max_bind_groups=4,
+    max_dynamic_uniform_buffers_per_pipeline_layout=8,
+    max_dynamic_storage_buffers_per_pipeline_layout=4,
+    max_sampled_textures_per_shader_stage=16,
+    max_samplers_per_shader_stage=16,
+    max_storage_buffers_per_shader_stage=4,
+    max_storage_textures_per_shader_stage=4,
+    max_uniform_buffers_per_shader_stage=12,
+)
 
 
 class GPUDevice(GPUObject):

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -11,7 +11,7 @@ class BaseCanvas:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._swapchain = None
+        self._swap_chain = None
         self._err_hashes = {}
         self._display_id = None
 
@@ -21,8 +21,8 @@ class BaseCanvas:
         previously returned by configureSwapChain, including all of the
         textures it has produced.
         """
-        self._swapchain = device._gui_configureSwapChain(self, format, usage)
-        return self._swapchain
+        self._swap_chain = device._gui_configure_swap_chain(self, format, usage)
+        return self._swap_chain
 
     def drawFrame(self):
         """ The function that gets called at each draw. You can implement
@@ -36,8 +36,8 @@ class BaseCanvas:
         """
         try:
             self.drawFrame()
-            if self._swapchain is not None:
-                self._swapchain._gui_present()  # a.k.a swap buffers
+            if self._swap_chain is not None:
+                self._swap_chain._gui_present()  # a.k.a swap buffers
         except Exception:
             # Enable PM debuging
             sys.last_type, sys.last_value, sys.last_traceback = sys.exc_info()

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -15,27 +15,27 @@ class BaseCanvas:
         self._err_hashes = {}
         self._display_id = None
 
-    def configureSwapChain(self, device, format, usage):
+    def configure_swap_chain(self, device, format, usage):
         """ Configures the swap chain for this canvas, and returns a
         new GPUSwapChain object representing it. Destroys any swapchain
-        previously returned by configureSwapChain, including all of the
+        previously returned by configure_swap_chain, including all of the
         textures it has produced.
         """
         self._swap_chain = device._gui_configure_swap_chain(self, format, usage)
         return self._swap_chain
 
-    def drawFrame(self):
+    def draw_frame(self):
         """ The function that gets called at each draw. You can implement
         this method in a subclass, or assign the attribute directly.
         """
         pass
 
-    def _drawFrameAndPresent(self):
+    def _draw_frame_and_present(self):
         """ Draw the frame and present the swapchain. Errors are printed to stderr.
         Should be called by the subclass at an appropriate time.
         """
         try:
-            self.drawFrame()
+            self.draw_frame()
             if self._swap_chain is not None:
                 self._swap_chain._gui_present()  # a.k.a swap buffers
         except Exception:
@@ -55,25 +55,25 @@ class BaseCanvas:
 
     # Methods that must be overloaded
 
-    def getSizeAndPixelRatio(self):
+    def get_size_and_pixel_ratio(self):
         """ Get a three-element tuple (width, height, pixelratio). This
         can be used internally (by the backends) to create the
         swapchain, and by users to determine the canvas size.
         """
         raise NotImplementedError()
 
-    def isClosed(self):
+    def is_closed(self):
         """ Whether the window is closed.
         """
         raise NotImplementedError()
 
-    def getWindowId(self):
+    def get_window_id(self):
         """ Get the native window id. This can be used by the backends
         to obtain a surface id.
         """
         raise NotImplementedError()
 
-    def getDisplayId(self):
+    def get_display_id(self):
         """ Get the native display id on Linux. This is needed by the backends
         to obtain a surface id on Linux.
         """

--- a/wgpu/gui/flexx.py
+++ b/wgpu/gui/flexx.py
@@ -12,17 +12,17 @@ class WgpuCanvas(flx.CanvasWidget):
 
     def init(self):
         self._draw_func = None
-        window.requestAnimationFrame(self._drawFrameAndPresent)
+        window.requestAnimationFrame(self._draw_frame_and_present)
 
-    def configureSwapChain(self, *args):
+    def configure_swap_chain(self, *args):
         return self.node.configureSwapChain(*args)
 
-    def drawFrame(self):
+    def draw_frame(self):
         pass
 
-    def _drawFrameAndPresent(self):
-        window.requestAnimationFrame(self._drawFrameAndPresent)
-        self.drawFrame()
+    def _draw_frame_and_present(self):
+        window.requestAnimationFrame(self._draw_frame_and_present)
+        self.draw_frame()
 
-    def isClosed(self):
+    def is_closed(self):
         return False

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -82,13 +82,13 @@ class GlfwWgpuCanvas(BaseCanvas):
         self._window = glfw.create_window(width, height, title, None, None)
         glfw.set_window_refresh_callback(self._window, self._paint)
 
-    def getSizeAndPixelRatio(self):
+    def get_size_and_pixel_ratio(self):
         # todo: maybe expose both logical size and physical size instead?
         width, height = glfw.get_window_size(self._window)
         pixelratio = glfw.get_window_content_scale(self._window)[0]
         return width, height, pixelratio
 
-    def getDisplayId(self):
+    def get_display_id(self):
         if sys.platform.startswith("linux"):
             is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
             if is_wayland:
@@ -98,7 +98,7 @@ class GlfwWgpuCanvas(BaseCanvas):
         else:
             raise RuntimeError(f"Cannot get GLFW display id on {sys.platform}.")
 
-    def getWindowId(self):
+    def get_window_id(self):
         if sys.platform.startswith("win"):
             return int(glfw.get_win32_window(self._window))
         elif sys.platform.startswith("darwin"):
@@ -113,9 +113,9 @@ class GlfwWgpuCanvas(BaseCanvas):
             raise RuntimeError(f"Cannot get GLFW window id on {sys.platform}.")
 
     def _paint(self, *args):
-        self._drawFrameAndPresent()
+        self._draw_frame_and_present()
 
-    def isClosed(self):
+    def is_closed(self):
         return glfw.window_should_close(self._window)
 
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -37,25 +37,25 @@ class QtWgpuCanvas(BaseCanvas, QWidget):
             self.setWindowTitle(title)
         self.show()
 
-    def paintEngine(self):
+    def paintEngine(self):  # noqa: N802 - this is a Qt method
         # https://doc.qt.io/qt-5/qt.html#WidgetAttribute-enum  WA_PaintOnScreen
         return None
 
-    def paintEvent(self, event):
-        self._drawFrameAndPresent()
+    def paintEvent(self, event):  # noqa: N802 - this is a Qt method
+        self._draw_frame_and_present()
 
-    def getSizeAndPixelRatio(self):
+    def get_size_and_pixel_ratio(self):
         return self.width(), self.height(), self.window().devicePixelRatio()
 
-    def isClosed(self):
+    def is_closed(self):
         return not self.isVisible()
 
-    def getDisplayId(self):
+    def get_display_id(self):
         # There is qx11info, but it is rarely available.
         # https://doc.qt.io/qt-5/qx11info.html#display
-        return super().getDisplayId()  # use X11 lib
+        return super().get_display_id()  # uses X11 lib
 
-    def getWindowId(self):
+    def get_window_id(self):
         return int(self.winId())
 
 

--- a/wgpu/gui/tk.py
+++ b/wgpu/gui/tk.py
@@ -29,22 +29,22 @@ class TkWgpuCanvas(BaseCanvas, tkinter.Toplevel):
         for ev_name in ["<Expose>", "<Configure>", "<Enter>"]:
             self.bind(ev_name, self._paint)
 
-    def getSizeAndPixelRatio(self):
+    def get_size_and_pixel_ratio(self):
         width = self.winfo_width()
         height = self.winfo_height()
         pixelratio = 1  # todo: pixelratio? Ask for it via win32 api?
         return width, height, pixelratio
 
-    def isClosed(self):
+    def is_closed(self):
         try:
             return self.wm_state() != "normal"
         except Exception:
             return True
 
-    def getDisplayId(self):
-        return super().getDisplayId()
+    def get_display_id(self):
+        return super().get_display_id()  # uses X11 lib
 
-    def getWindowId(self):
+    def get_window_id(self):
         # There's two functions of interest here. On Linux they return the same
         # value (for a toplevel widget), but on Windows not, and frame() does
         # not work.
@@ -56,7 +56,7 @@ class TkWgpuCanvas(BaseCanvas, tkinter.Toplevel):
 
     def _paint(self, *args):
         # Actual drawing needs to happen *after* Tcl draws bg
-        self.after(1, self._drawFrameAndPresent)
+        self.after(1, self._draw_frame_and_present)
 
 
 WgpuCanvas = TkWgpuCanvas

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -97,8 +97,8 @@
 *  Not implemented: constructor();
 *  Not implemented: constructor(DOMString message);
 *  Not implemented: constructor( DOMString type, GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict );
-*  Found unknown function DictLike.get
-*  Found unknown function GPUSwapChain.getCurrentTextureView
+*  Found unknown function get (dictlikeget)
+*  Found unknown function get_current_texture_view (swapchaingetcurrenttextureview)
 *  Injected IDL lines into base.py
 
 ### Check functions in backend/rs.py
@@ -126,7 +126,7 @@
 *  Not implemented: constructor();
 *  Not implemented: constructor(DOMString message);
 *  Not implemented: constructor( DOMString type, GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict );
-*  Found unknown function new_struct
-*  Found unknown function get_surface_id_from_canvas
-*  Found unknown function GPUSwapChain.getCurrentTextureView
+*  Found unknown function new_struct (newstruct)
+*  Found unknown function get_surface_id_from_canvas (getsurfaceidfromcanvas)
+*  Found unknown function get_current_texture_view (swapchaingetcurrenttextureview)
 *  Injected IDL lines into backend/rs.py

--- a/wgpu/utils/__init__.py
+++ b/wgpu/utils/__init__.py
@@ -14,3 +14,4 @@ Higher level utility functions. This module is not imported by default.
 # API itself.
 
 from ._compute import compute_with_buffers  # noqa: F401
+from ._device import create_device  # noqa: F401

--- a/wgpu/utils/_device.py
+++ b/wgpu/utils/_device.py
@@ -1,0 +1,8 @@
+def create_device():
+    """ Create a wgpu device object. If this succeeds, it's likely that
+    the WGPU lib is usable on this system. If not, this call will
+    probably exit (Rust panic). returns None.
+    """
+    import wgpu.backend.rs
+
+    wgpu.request_adapter(power_preference="high-performance").request_device()


### PR DESCRIPTION
Closes #57 

* flags: name is CamelCase, field names are UPPERCASE, values are int.
* enums: name is CamelCase, field names are snake_case, values are 'like-this'.
* structs: their fields are the function arguments, so we never refer them by name.
* function args: name is snake_case. 
* function names: name is snake_case.