### PR TITLE
Add support for creating wgpu surface on macOS

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,6 @@ requests
 setuptools
 wheel
 twine
-cffi>=1.10
 python-shader>=0.3.4
 auditwheel; sys_platform == 'linux'
 pyinstaller[hook_testing] @ https://github.com/bjones1/pyinstaller/archive/4232a.zip

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ requests
 setuptools
 wheel
 twine
+cffi>=1.10
 python-shader>=0.3.4
 auditwheel; sys_platform == 'linux'
 pyinstaller[hook_testing] @ https://github.com/bjones1/pyinstaller/archive/4232a.zip

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -30,6 +30,7 @@ Developer notes and tips:
 import os
 import sys
 import ctypes
+import ctypes.util
 from weakref import WeakKeyDictionary
 
 from cffi import FFI, __version_info__ as cffi_version_info
@@ -138,7 +139,6 @@ def get_surface_id_from_canvas(canvas):
         return _lib.wgpu_create_surface_from_windows_hwnd(hinstance, hwnd)
     elif sys.platform.startswith("darwin"):
         # wgpu_create_surface_from_metal_layer(void *layer)
-        # todo: MacOS support
         # This is what the triangle example from wgpu-native does:
         # #if WGPU_TARGET == WGPU_TARGET_MACOS
         #     {
@@ -149,8 +149,45 @@ def get_surface_id_from_canvas(canvas):
         #         [ns_window.contentView setLayer:metal_layer];
         #         surface = wgpu_create_surface_from_metal_layer(metal_layer);
         #     }
-        layer = ffi.cast("void *", win_id)
-        return _lib.wgpu_create_surface_from_metal_layer(layer)
+        window = ctypes.c_void_p(win_id)
+
+        objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
+        objc.objc_getClass.restype = ctypes.c_void_p
+        objc.sel_registerName.restype = ctypes.c_void_p
+        objc.objc_msgSend.restype = ctypes.c_void_p
+        objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        content_view_sel = objc.sel_registerName(b'contentView')
+        set_wants_layer_sel = objc.sel_registerName(b'setWantsLayer:')
+        responds_to_sel_sel = objc.sel_registerName(b'respondsToSelector:')
+        layer_sel = objc.sel_registerName(b'layer')
+        set_layer_sel = objc.sel_registerName(b'setLayer:')
+
+        # Try some duck typing to see what kind of object the window pointer points to
+        # Qt doesn't return a NSWindow, but a QNSView instead, which is subclass of NSView.
+        if (objc.objc_msgSend(window, responds_to_sel_sel, ctypes.c_void_p(content_view_sel))):
+            # NSWindow instances respond to contentView selector
+            content_view = objc.objc_msgSend(window, content_view_sel)
+        elif (objc.objc_msgSend(window, responds_to_sel_sel, ctypes.c_void_p(layer_sel))):
+            # NSView instances respond to layer selector
+            # Let's assume that the given window pointer is actually the content view
+            content_view = window
+        else:
+            # Can't tell what kind of object window is
+            raise TypeError()
+
+        # [ns_window.contentView setWantsLayer:YES]
+        objc.objc_msgSend(content_view, set_wants_layer_sel, True)
+
+        # metal_layer = [CAMetalLayer layer];
+        CAMetalLayer = objc.objc_getClass(b'CAMetalLayer')
+        metal_layer = objc.objc_msgSend(CAMetalLayer, layer_sel)
+
+        # [ns_window.content_view setLayer:metal_layer];
+        objc.objc_msgSend(content_view, set_layer_sel, ctypes.c_void_p(metal_layer))
+
+        metal_layer_ffi_pointer = ffi.cast("void *", metal_layer)
+        return _lib.wgpu_create_surface_from_metal_layer(metal_layer_ffi_pointer)
     elif sys.platform.startswith("linux"):
         # wgpu_create_surface_from_wayland(void *surface, void *display)
         # wgpu_create_surface_from_xlib(const void **display, uint64_t window)

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -182,8 +182,8 @@ def get_surface_id_from_canvas(canvas):
         objc.objc_msgSend(content_view, set_wants_layer_sel, True)
 
         # metal_layer = [CAMetalLayer layer];
-        CAMetalLayer = objc.objc_getClass(b"CAMetalLayer")
-        metal_layer = objc.objc_msgSend(CAMetalLayer, layer_sel)
+        ca_metal_layer_class = objc.objc_getClass(b"CAMetalLayer")
+        metal_layer = objc.objc_msgSend(ca_metal_layer_class, layer_sel)
 
         # [ns_window.content_view setLayer:metal_layer];
         objc.objc_msgSend(content_view, set_layer_sel, ctypes.c_void_p(metal_layer))

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -151,24 +151,26 @@ def get_surface_id_from_canvas(canvas):
         #     }
         window = ctypes.c_void_p(win_id)
 
-        objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
+        objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
         objc.objc_getClass.restype = ctypes.c_void_p
         objc.sel_registerName.restype = ctypes.c_void_p
         objc.objc_msgSend.restype = ctypes.c_void_p
         objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-        content_view_sel = objc.sel_registerName(b'contentView')
-        set_wants_layer_sel = objc.sel_registerName(b'setWantsLayer:')
-        responds_to_sel_sel = objc.sel_registerName(b'respondsToSelector:')
-        layer_sel = objc.sel_registerName(b'layer')
-        set_layer_sel = objc.sel_registerName(b'setLayer:')
+        content_view_sel = objc.sel_registerName(b"contentView")
+        set_wants_layer_sel = objc.sel_registerName(b"setWantsLayer:")
+        responds_to_sel_sel = objc.sel_registerName(b"respondsToSelector:")
+        layer_sel = objc.sel_registerName(b"layer")
+        set_layer_sel = objc.sel_registerName(b"setLayer:")
 
         # Try some duck typing to see what kind of object the window pointer points to
         # Qt doesn't return a NSWindow, but a QNSView instead, which is subclass of NSView.
-        if (objc.objc_msgSend(window, responds_to_sel_sel, ctypes.c_void_p(content_view_sel))):
+        if objc.objc_msgSend(
+            window, responds_to_sel_sel, ctypes.c_void_p(content_view_sel)
+        ):
             # NSWindow instances respond to contentView selector
             content_view = objc.objc_msgSend(window, content_view_sel)
-        elif (objc.objc_msgSend(window, responds_to_sel_sel, ctypes.c_void_p(layer_sel))):
+        elif objc.objc_msgSend(window, responds_to_sel_sel, ctypes.c_void_p(layer_sel)):
             # NSView instances respond to layer selector
             # Let's assume that the given window pointer is actually the content view
             content_view = window
@@ -180,7 +182,7 @@ def get_surface_id_from_canvas(canvas):
         objc.objc_msgSend(content_view, set_wants_layer_sel, True)
 
         # metal_layer = [CAMetalLayer layer];
-        CAMetalLayer = objc.objc_getClass(b'CAMetalLayer')
+        CAMetalLayer = objc.objc_getClass(b"CAMetalLayer")
         metal_layer = objc.objc_msgSend(CAMetalLayer, layer_sel)
 
         # [ns_window.content_view setLayer:metal_layer];

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -175,8 +175,9 @@ def get_surface_id_from_canvas(canvas):
             # Let's assume that the given window pointer is actually the content view
             content_view = window
         else:
-            # Can't tell what kind of object window is
-            raise TypeError()
+            # If the code reaches this part, we know that `window` is an
+            # objective-c object but the type is neither NSView or NSWindow.
+            raise RuntimeError("Received unidentified objective-c object.")
 
         # [ns_window.contentView setWantsLayer:YES]
         objc.objc_msgSend(content_view, set_wants_layer_sel, True)

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -81,6 +81,13 @@ class GlfwWgpuCanvas(BaseCanvas):
 
         self._window = glfw.create_window(width, height, title, None, None)
         glfw.set_window_refresh_callback(self._window, self._paint)
+        if sys.platform.startswith("darwin"):
+            # Apparently, the refresh_callback is not called when the window
+            # is created, gets focus, or is resized on macOS. So this is a
+            # workaround to explicitely make sure that the paint callback
+            # is called so that the contents are drawn.
+            glfw.set_window_focus_callback(self._window, self._paint)
+            glfw.set_window_size_callback(self._window, self._paint)
 
     def get_size_and_pixel_ratio(self):
         # todo: maybe expose both logical size and physical size instead?

--- a/wgpu/gui/tk.py
+++ b/wgpu/gui/tk.py
@@ -51,6 +51,10 @@ class TkWgpuCanvas(BaseCanvas, tkinter.Toplevel):
         # * self.winfo_id(): platform-specific identifier for window
         # * self.frame(): platform specific window identifier for the
         #   outermost frame that contains window
+        # On macOS, the object from winfo_id doesn't seem to be an obj-c object
+        # and there is no clear way of getting a hold of the top-level NSView
+        # object. Needs further investigation. The `wm_frame` and `frame` methods
+        # both return the same id as `winfo_id`.
         return int(self.winfo_id())
         # return int(self.frame(), 16)
 


### PR DESCRIPTION
Here is the work we did on calling objective-c methods with ctypes, to replicate the example code from wgpu-native. Works for Qt and GLFW.

Closes #29