### PR TITLE
Implement indirect drawing

### DIFF
--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -55,13 +55,12 @@ print(result[:])
 # %% The long version using the wgpu API
 
 # Create device and shader object
-adapter = wgpu.request_adapter(power_preference="high-performance")
-device = adapter.request_device(extensions=[], limits={})
+device = wgpu.utils.get_default_device()
 cshader = device.create_shader_module(code=compute_shader)
 
 # Create buffer objects, input buffer is mapped.
 buffer1 = device.create_buffer_mapped(
-    size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ
+    size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE
 )
 buffer2 = device.create_buffer(
     size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -66,6 +66,7 @@ def render_to_texture(
     ibo=None,
     vbos=None,
     vbo_views=None,
+    indirect_buffer=None,
     color_attachment=None,
     depth_stencil_state=None,
     depth_stencil_attachment=None,
@@ -157,10 +158,16 @@ def render_to_texture(
         render_pass.set_vertex_buffer(slot, vbo, 0)
     renderpass_callback(render_pass)
     if ibo is None:
-        render_pass.draw(4, 1, 0, 0)
+        if indirect_buffer is None:
+            render_pass.draw(4, 1, 0, 0)
+        else:
+            render_pass.draw_indirect(indirect_buffer, 0)
     else:
         render_pass.set_index_buffer(ibo, 0)
-        render_pass.draw_indexed(6, 1, 0, 0, 0)
+        if indirect_buffer is None:
+            render_pass.draw_indexed(6, 1, 0, 0, 0)
+        else:
+            render_pass.draw_indexed_indirect(indirect_buffer, 0)
     render_pass.end_pass()
     command_encoder.copy_texture_to_buffer(
         {"texture": texture, "mip_level": 0, "array_layer": 0, "origin": (0, 0, 0)},
@@ -186,6 +193,7 @@ def render_to_screen(
     ibo=None,
     vbos=None,
     vbo_views=None,
+    indirect_buffer=None,
     color_attachment=None,
     depth_stencil_state=None,
     depth_stencil_attachment=None,
@@ -270,10 +278,16 @@ def render_to_screen(
             render_pass.set_vertex_buffer(slot, vbo, 0)
         renderpass_callback(render_pass)
         if ibo is None:
-            render_pass.draw(4, 1, 0, 0)
+            if indirect_buffer is None:
+                render_pass.draw(4, 1, 0, 0)
+            else:
+                render_pass.draw_indirect(indirect_buffer, 0)
         else:
             render_pass.set_index_buffer(ibo, 0)
-            render_pass.draw_indexed(6, 1, 0, 0, 0)
+            if indirect_buffer is None:
+                render_pass.draw_indexed(6, 1, 0, 0, 0)
+            else:
+                render_pass.draw_indexed_indirect(indirect_buffer, 0)
         render_pass.end_pass()
         device.default_queue.submit([command_encoder.finish()])
 

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1170,11 +1170,12 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
     def dispatch(self, x, y, z):
         _lib.wgpu_compute_pass_dispatch(self._internal, x, y, z)
 
-    # def dispatch_indirect(self, indirect_buffer, indirect_offset):
-    #     buffer_id = indirect_buffer._internal
-    #     _lib.wgpu_compute_pass_dispatch_indirect(
-    #         self._internal, buffer_id, indirect_offset
-    #     )
+    # wgpu.help('Buffer', 'Size64', 'computepassencoderdispatchindirect', dev=True)
+    def dispatch_indirect(self, indirect_buffer, indirect_offset):
+        buffer_id = indirect_buffer._internal
+        _lib.wgpu_compute_pass_dispatch_indirect(
+            self._internal, buffer_id, int(indirect_offset)
+        )
 
     # wgpu.help('computepassencoderendpass', dev=True)
     def end_pass(self):
@@ -1209,9 +1210,12 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
             self._internal, vertex_count, instance_count, first_vertex, first_instance
         )
 
-    # todo: missing API
-    # def draw_indirect(self, indirect_buffer, indirect_offset):
-    #     ...
+    # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindirect', dev=True)
+    def draw_indirect(self, indirect_buffer, indirect_offset):
+        buffer_id = indirect_buffer._internal
+        _lib.wgpu_render_pass_draw_indirect(
+            self._internal, buffer_id, int(indirect_offset)
+        )
 
     # wgpu.help('SignedOffset32', 'Size32', 'renderencoderbasedrawindexed', dev=True)
     def draw_indexed(
@@ -1226,9 +1230,12 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
             first_instance,
         )
 
-    # todo: missing API
-    # def draw_indexed_indirect(self, indirect_buffer, indirect_offset):
-    #     ...
+    # wgpu.help('Buffer', 'Size64', 'renderencoderbasedrawindexedindirect', dev=True)
+    def draw_indexed_indirect(self, indirect_buffer, indirect_offset):
+        buffer_id = indirect_buffer._internal
+        _lib.wgpu_render_pass_draw_indexed_indirect(
+            self._internal, buffer_id, int(indirect_offset)
+        )
 
 
 class GPURenderPassEncoder(GPURenderEncoderBase):
@@ -1265,7 +1272,6 @@ class GPURenderPassEncoder(GPURenderEncoderBase):
     def set_stencil_reference(self, reference):
         _lib.wgpu_render_pass_set_stencil_reference(self._internal, int(reference))
 
-    # todo: missing api
     # Not sure what this function exists in the Rust API, because there is no
     # way to create bundles yet?
     # def execute_bundles(self, bundles):

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -97,7 +97,7 @@
 *  Injected IDL lines into base.py
 
 ### Check functions in backends/rs.py
-*  Found 45 functions already implemented
+*  Found 48 functions already implemented
 *  Not implemented: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
 *  Not implemented: void pushDebugGroup(DOMString groupLabel);
 *  Not implemented: void popDebugGroup();
@@ -105,9 +105,6 @@
 *  Not implemented: void pushDebugGroup(DOMString groupLabel);
 *  Not implemented: void popDebugGroup();
 *  Not implemented: void insertDebugMarker(DOMString markerLabel);
-*  Not implemented: void dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-*  Not implemented: void drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-*  Not implemented: void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 *  Not implemented: void executeBundles(sequence<GPURenderBundle> bundles);
 *  Not implemented: GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 *  Not implemented: GPUFence createFence(optional GPUFenceDescriptor descriptor = {});


### PR DESCRIPTION
These new tests actually fail in the lib shipped with the library, because the `BufferUsage.INDIRECT` enum was [changed at some point](https://github.com/gfx-rs/wgpu/pull/468/files). It looks like
the .h file that we use does not precisely match the library. Eek!

Anyway, let's just merge this, and update to the latest wgpu-native.