### PR TITLE
Implement request_draw

### DIFF
--- a/examples/triangle_glfw.py
+++ b/examples/triangle_glfw.py
@@ -3,19 +3,40 @@ Import the viz from triangle.py and run it in a glfw window.
 The glfw library can be installed using ``pip install glfw``.
 """
 
+import math
+from time import perf_counter
+
 import glfw
-from wgpu.gui.glfw import WgpuCanvas  # WgpuCanvas wraps a glfw window
+from wgpu.gui.glfw import update_glfw_canvasses, WgpuCanvas
 import wgpu.backends.rs  # noqa: F401, Select Rust backend
 
-# Import the (async) function that we must call to run the visualization
-
+# Import the function that we must call to run the visualization
 from triangle import main
 
 
 glfw.init()
 canvas = WgpuCanvas(title="wgpu triangle with GLFW")
-
 main(canvas)
-while not canvas.is_closed():
-    glfw.poll_events()
+
+
+def simple_event_loop():
+    """ A real simple event loop, but it keeps the CPU busy. """
+    while update_glfw_canvasses():
+        glfw.poll_events()
+
+
+def better_event_loop(max_fps=100):
+    """ A simple event loop that schedules draws. """
+    td = 1 / max_fps
+    while update_glfw_canvasses():
+        # Determine next time to draw
+        now = perf_counter()
+        tnext = math.ceil(now / td) * td
+        # Process events until it's time to draw
+        while now < tnext:
+            glfw.wait_events_timeout(tnext - now)
+            now = perf_counter()
+
+
+better_event_loop()
 glfw.terminate()

--- a/examples/triangle_glfw_asyncio.py
+++ b/examples/triangle_glfw_asyncio.py
@@ -7,7 +7,7 @@ The glfw library can be installed using ``pip install glfw``.
 import asyncio  # noqa: E402
 
 import glfw
-from wgpu.gui.glfw import WgpuCanvas  # WgpuCanvas wraps a glfw window
+from wgpu.gui.glfw import update_glfw_canvasses, WgpuCanvas
 import wgpu.backends.rs  # noqa: F401, Select Rust backend
 
 # Import the (async) function that we must call to run the visualization
@@ -20,7 +20,7 @@ canvas = WgpuCanvas(size=(640, 480), title="wgpu triangle with GLFW")
 
 async def mainloop():
     await main_async(canvas)
-    while not canvas.is_closed():
+    while update_glfw_canvasses():
         await asyncio.sleep(0.001)
         glfw.poll_events()
     loop.stop()

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -38,8 +38,8 @@ class BaseCanvas:
         pass
 
     def _draw_frame_and_present(self):
-        """ Draw the frame and present the swapchain. Errors are printed to stderr.
-        Should be called by the subclass at an appropriate time.
+        """ Draw the frame and present the swapchain. Errors are logged to the
+        "wgpu" logger. Should be called by the subclass at an appropriate time.
         """
         # Perform the user-defined drawing code. When this errors,
         # we should report the error and then continue, otherwise we crash.
@@ -51,7 +51,7 @@ class BaseCanvas:
         # Always present the swapchain, or wgpu gets into an error state.
         try:
             if self._swap_chain is not None:
-                self._swap_chain._gui_present()  # a.k.a swap buffers
+                self._swap_chain._gui_present()  # a.k.a. swap buffers
         except Exception as err:
             self._log_exception("Swapchain present error", err)
 
@@ -78,7 +78,8 @@ class BaseCanvas:
 
     def get_display_id(self):
         """ Get the native display id on Linux. This is needed by the backends
-        to obtain a surface id on Linux.
+        to obtain a surface id on Linux. The default implementation calls into
+        the X11 lib to get the display id.
         """
         # Re-use to avoid creating loads of id's
         if self._display_id is not None:
@@ -125,12 +126,18 @@ class BaseCanvas:
         """
         raise NotImplementedError()
 
+    def request_draw(self):
+        """ Request from the main loop to schedule a new draw event,
+        so that the canvas will be updated.
+        """
+        raise NotImplementedError()
+
     def close(self):
         """ Close the window.
         """
         raise NotImplementedError()
 
     def is_closed(self):
-        """ Whether the window is closed.
+        """ Get whether the window is closed.
         """
         raise NotImplementedError()

--- a/wgpu/gui/flexx.py
+++ b/wgpu/gui/flexx.py
@@ -24,5 +24,8 @@ class WgpuCanvas(flx.CanvasWidget):
         window.requestAnimationFrame(self._draw_frame_and_present)
         self.draw_frame()
 
+    def request_draw(self):
+        pass  # already drawing continuously
+
     def is_closed(self):
         return False

--- a/wgpu/gui/flexx.py
+++ b/wgpu/gui/flexx.py
@@ -2,6 +2,9 @@ from flexx import flx
 from pscript.stubs import window
 
 
+raise NotImplementedError()
+
+
 # Flexx cannot do multiple inheritance, so we consider BaseCanvas an interface :)
 
 
@@ -12,7 +15,10 @@ class WgpuCanvas(flx.CanvasWidget):
 
     def init(self):
         self._draw_func = None
-        window.requestAnimationFrame(self._draw_frame_and_present)
+        self._draw_pending = False
+
+        self.node.addEventListener("size", self.request_draw)
+        self.request_draw()
 
     def configure_swap_chain(self, *args):
         return self.node.configureSwapChain(*args)
@@ -21,11 +27,13 @@ class WgpuCanvas(flx.CanvasWidget):
         pass
 
     def _draw_frame_and_present(self):
-        window.requestAnimationFrame(self._draw_frame_and_present)
+        self._draw_pending = False
         self.draw_frame()
 
     def request_draw(self):
-        pass  # already drawing continuously
+        if not self._draw_pending:
+            self._draw_pending = True
+            window.requestAnimationFrame(self._draw_frame_and_present)
 
     def is_closed(self):
         return False

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -26,7 +26,9 @@ def enable_hidpi():
     """ Enable high-res displays.
     """
     try:
-        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+        # See https://github.com/pyzo/pyzo/pull/700 why we seem to need both
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)  # global dpi aware
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)  # per-monitor dpi aware
     except Exception:
         pass  # fail on non-windows
     try:
@@ -105,6 +107,9 @@ class QtWgpuCanvas(BaseCanvas, QtWidgets.QWidget):
         if width < 0 or height < 0:
             raise ValueError("Window width and height must not be negative")
         self.resize(width, height)  # See note on pixel ratio below
+
+    def request_draw(self):
+        self.update()
 
     def close(self):
         super().close()


### PR DESCRIPTION
Closes #63 

* For qt this is easy, because it's an alias for `update()`.
* For glfw it's more involved, because glfw does not provide an event loop. So I've made a function that one must call from your glfw mainloop, which will redraw all canvases that are invalidated.
* Updated the glfw tests (they check that multiple events or draw requests result in a single draw)
* The glfw example has a more sophisticated event loop that does not turn your laptop into a heater,
