### PR TITLE
Allow passing canvas to request_adapter

### DIFF
--- a/codegen-script.py
+++ b/codegen-script.py
@@ -359,15 +359,13 @@ for fname in ("base.py", "backends/rs.py"):
                 py_args = [field.py_arg() for field in arg_struct.values()]
                 if py_args[0] == "label: str":
                     py_args[0] = 'label=""'
-                if "requestadapter" in func_id:
-                    py_args = ["*"] + py_args
-                else:
                     py_args = ["self", "*"] + py_args
             else:
                 py_args = ["self"] + argnames
 
             # Replace function signature
-            api_lines[i] = preamble + ", ".join(py_args) + "):"
+            if "requestadapter" not in func_id:
+                api_lines[i] = preamble + ", ".join(py_args) + "):"
 
             # Insert comments
             if fname == "base.py":

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -47,7 +47,7 @@ def fragment_shader(
 def main(canvas):
     """ Regular function to setup a viz on the given canvas.
     """
-    adapter = wgpu.request_adapter(power_preference="high-performance")
+    adapter = wgpu.request_adapter(canvas=canvas, power_preference="high-performance")
     device = adapter.request_device(extensions=[], limits={})
     return _main(canvas, device)
 
@@ -55,7 +55,9 @@ def main(canvas):
 async def main_async(canvas):
     """ Async function to setup a viz on the given canvas.
     """
-    adapter = await wgpu.request_adapter_async(power_preference="high-performance")
+    adapter = await wgpu.request_adapter_async(
+        canvas=canvas, power_preference="high-performance"
+    )
     device = await adapter.request_device_async(extensions=[], limits={})
     return _main(canvas, device)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,10 @@ def test_basic_api():
     assert wgpu.help
     assert wgpu.request_adapter
     assert wgpu.request_adapter_async
+    assert (
+        wgpu.base.request_adapter.__code__.co_varnames
+        == wgpu.base.request_adapter_async.__code__.co_varnames
+    )
 
 
 def test_enums_and_flags():
@@ -34,7 +38,7 @@ def test_enums_and_flags():
 def test_base_wgpu_api():
 
     with raises(RuntimeError) as error:
-        wgpu.base.request_adapter(power_preference="high-performance")
+        wgpu.base.request_adapter(canvas=None, power_preference="high-performance")
     assert "select a backend" in str(error.value).lower()
 
     # Fake a device and an adapter

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -88,8 +88,10 @@ def test_shader_module_creation():
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_adapter_destroy():
-    adapter = wgpu.request_adapter(power_preference="high-performance")
+    adapter = wgpu.request_adapter(canvas=None, power_preference="high-performance")
+    assert adapter._id is not None
     adapter.__del__()
+    assert adapter._id is None
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")

--- a/wgpu/backends/js.py
+++ b/wgpu/backends/js.py
@@ -11,12 +11,12 @@ from .. import _register_backend
 from pscript.stubs import window
 
 
-def request_adapter(options):
+def request_adapter(**parameters):
     raise NotImplementedError("Cannot use sync API functions in JS.")
 
 
-async def request_adapter_async(options):
-    return await window.navigator.gpu.request_adapter(options)
+async def request_adapter_async(**parameters):
+    return await window.navigator.gpu.request_adapter(**parameters)
 
 
 # Mark as the backend at import time

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -273,18 +273,27 @@ def _loadop_and_clear_from_value(value):
 
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
-def request_adapter(*, power_preference: "GPUPowerPreference"):
-    """ Request an GPUAdapter, the object that represents the implementation of WGPU.
-    This function uses the Rust WGPU library.
+def request_adapter(*, canvas, power_preference: "GPUPowerPreference"):
+    """ Get a :class:`GPUAdapter`, the object that represents an abstract wgpu
+    implementation, from which one can request a :class:`GPUDevice`.
 
-    Params:
-        power_preference(enum): "high-performance" or "low-power"
+    This is the implementation based on the Rust wgpu-native library.
+
+    Arguments:
+        canvas (WgpuCanvas): The canvas that the adapter should be able to
+            render to (to create a swap chain for, to be precise). Can be None
+            if you're not rendering to screen (or if you're confident that the
+            returned adapter will work just fine).
+        powerPreference(PowerPreference): "high-performance" or "low-power"
     """
 
-    # todo: if we don't pass a valid surface id, there is no guarantee we'll
-    # be able to create a swapchain for it (from this adapter)
-    # Also, in visvis2 we had to memoize the surface id, must we do it too?
-    surface_id = 0  # get_surface_id_from_canvas(canvas)
+    # Get surface id that the adapter must be compatible with. If we
+    # don't pass a valid surface id, there is no guarantee we'll be
+    # able to create a swapchain for it (from this adapter).
+    if canvas is None:
+        surface_id = 0
+    else:
+        surface_id = get_surface_id_from_canvas(canvas)
 
     # Convert the descriptor
     struct = new_struct(
@@ -324,11 +333,11 @@ def request_adapter(*, power_preference: "GPUPowerPreference"):
 
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
-async def request_adapter_async(*, power_preference: "GPUPowerPreference"):
+async def request_adapter_async(*, canvas, power_preference: "GPUPowerPreference"):
     """ Async version of ``request_adapter()``.
     This function uses the Rust WGPU library.
     """
-    return request_adapter(power_preference=power_preference)  # no-cover
+    return request_adapter(canvas=canvas, power_preference=power_preference)  # no-cover
 
 
 # Mark as the backend at import time

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -21,11 +21,15 @@ logger = logging.getLogger("wgpu")
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
 # IDL: Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
-def request_adapter(*, power_preference: "GPUPowerPreference"):
+def request_adapter(*, canvas, power_preference: "GPUPowerPreference"):
     """ Get a :class:`GPUAdapter`, the object that represents an abstract wgpu
     implementation, from which one can request a :class:`GPUDevice`.
 
     Arguments:
+        canvas (WgpuCanvas): The canvas that the adapter should be able to
+            render to (to create a swap chain for, to be precise). Can be None
+            if you're not rendering to screen (or if you're confident that the
+            returned adapter will work just fine).
         powerPreference(PowerPreference): "high-performance" or "low-power"
     """
     raise RuntimeError(
@@ -35,7 +39,7 @@ def request_adapter(*, power_preference: "GPUPowerPreference"):
 
 # wgpu.help('RequestAdapterOptions', 'requestadapter', dev=True)
 # IDL: Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
-async def request_adapter_async(*, power_preference: "GPUPowerPreference"):
+async def request_adapter_async(*, canvas, power_preference: "GPUPowerPreference"):
     """ Async version of ``request_adapter()``.
     """
     raise RuntimeError(

--- a/wgpu/utils/_device.py
+++ b/wgpu/utils/_device.py
@@ -12,6 +12,6 @@ def get_default_device():
     if _default_device is None:
         import wgpu.backends.rs  # noqa
 
-        adapter = wgpu.request_adapter(power_preference="high-performance")
+        adapter = wgpu.request_adapter(canvas=None, power_preference="high-performance")
         _default_device = adapter.request_device()
     return _default_device


### PR DESCRIPTION
The `request_adapter` in wgpu-native now supports passing the surface id, so that we can make sure that the returned adapter is actually compatible with that (or such type of) surface.

I considered a few options to express this in the API, and this seems to be the most straightforward, even though it makes the API deviate from WebGPU somewhat (because in WebGPU the browser knows the surface id, so the user does not need pass it). Made it a required argument, so that it's obvious when it's set to None.

It's quite liberating that in an API that's low-level, we can afford to be a bit verbose at times :)