### PR TITLE
Debug markers

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -64,6 +64,10 @@ You can run your application via RenderDoc, which is able to capture a
 frame, including all API calls, objects and the complete pipeline state
 and displays all of that information within a nice UI.
 
+Many GPU objects can be given a string label. This label will be used
+in Rust validation errors, and are also used in e.g. RenderDoc to
+identify objects.
+
 Additionally, you can insert debug markers at the render/compute pass
 object, which will then show up in RenderDoc.
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -54,6 +54,20 @@ be between 0.0 and 1.0 inclusive. Vertices out of this range in NDC
 will not introduce any errors, but they will be clipped.
 
 
+Debugging
+---------
+
+If you want to debug your application, it's adviced to use a debug build
+of wgpu-native, because this will enable the validation layers.
+
+You can run your application via RenderDoc, which is able to capture a
+frame, including all API calls, objects and the complete pipeline state
+and displays all of that information within a nice UI.
+
+Additionally, you can insert debug markers at the render/compute pass
+object, which will then show up in RenderDoc.
+
+
 Examples
 --------
 

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -279,14 +279,20 @@ def render_to_screen(
             depth_stencil_attachment=depth_stencil_attachment,
             occlusion_query_set=None,
         )
+        render_pass.push_debug_group("foo")
 
+        render_pass.insert_debug_marker("setting pipeline")
         render_pass.set_pipeline(render_pipeline)
+        render_pass.insert_debug_marker("setting bind group")
         render_pass.set_bind_group(
             0, bind_group, [], 0, 999999
         )  # last 2 elements not used
         for slot, vbo in enumerate(vbos):
+            render_pass.insert_debug_marker(f"setting vbo {slot}")
             render_pass.set_vertex_buffer(slot, vbo, 0, vbo.size)
+        render_pass.insert_debug_marker("invoking callback")
         renderpass_callback(render_pass)
+        render_pass.insert_debug_marker("draw!")
         if ibo is None:
             if indirect_buffer is None:
                 render_pass.draw(4, 1, 0, 0)
@@ -298,6 +304,7 @@ def render_to_screen(
                 render_pass.draw_indexed(6, 1, 0, 0, 0)
             else:
                 render_pass.draw_indexed_indirect(indirect_buffer, 0)
+        render_pass.pop_debug_group()
         render_pass.end_pass()
         device.default_queue.submit([command_encoder.finish()])
 

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -70,7 +70,7 @@ def render_to_texture(
     color_attachment=None,
     depth_stencil_state=None,
     depth_stencil_attachment=None,
-    renderpass_callback=lambda *args: None
+    renderpass_callback=lambda *args: None,
 ):
 
     # https://github.com/gfx-rs/wgpu-rs/blob/master/examples/capture/main.rs
@@ -152,12 +152,18 @@ def render_to_texture(
         depth_stencil_attachment=depth_stencil_attachment,
         occlusion_query_set=None,
     )
+    render_pass.push_debug_group("foo")
 
+    render_pass.insert_debug_marker("setting pipeline")
     render_pass.set_pipeline(render_pipeline)
+    render_pass.insert_debug_marker("setting bind group")
     render_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 elements not used
     for slot, vbo in enumerate(vbos):
+        render_pass.insert_debug_marker(f"setting vbo {slot}")
         render_pass.set_vertex_buffer(slot, vbo, 0, vbo.size)
+    render_pass.insert_debug_marker(f"invoking callback")
     renderpass_callback(render_pass)
+    render_pass.insert_debug_marker(f"draw!")
     if ibo is None:
         if indirect_buffer is None:
             render_pass.draw(4, 1, 0, 0)
@@ -169,6 +175,7 @@ def render_to_texture(
             render_pass.draw_indexed(6, 1, 0, 0, 0)
         else:
             render_pass.draw_indexed_indirect(indirect_buffer, 0)
+    render_pass.pop_debug_group()
     render_pass.end_pass()
     command_encoder.copy_texture_to_buffer(
         {"texture": texture, "mip_level": 0, "array_layer": 0, "origin": (0, 0, 0)},
@@ -198,7 +205,7 @@ def render_to_screen(
     color_attachment=None,
     depth_stencil_state=None,
     depth_stencil_attachment=None,
-    renderpass_callback=lambda *args: None
+    renderpass_callback=lambda *args: None,
 ):
     """ Render to a window on screen, for debugging purposes.
     """

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -82,7 +82,10 @@ def test_glfw_canvas_render():
     from wgpu.gui.glfw import update_glfw_canvasses, WgpuCanvas
 
     canvas = WgpuCanvas()
-    device = get_default_device()
+
+    # wgpu.utils.get_default_device()
+    adapter = wgpu.request_adapter(canvas=canvas, power_preference="high-performance")
+    device = adapter.request_device()
 
     # Bindings and layout
     bind_group_layout = device.create_bind_group_layout(entries=[])  # zero bindings

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -9,7 +9,7 @@ from python_shader import python2shader, vec4, i32
 from python_shader import RES_INPUT, RES_OUTPUT
 import wgpu.backends.rs  # noqa
 from pytest import skip
-from testutils import can_use_wgpu_lib, get_default_device
+from testutils import can_use_wgpu_lib
 from renderutils import render_to_texture, render_to_screen  # noqa
 
 

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -20,10 +20,10 @@ def test_override_wgpu_lib_path():
 
     # Change it
     old_env_var = os.environ.get("WGPU_LIB_PATH", None)
-    os.environ["WGPU_LIB_PATH"] = __file__  # because it must be a valid path
+    os.environ["WGPU_LIB_PATH"] = "foo/bar"
 
     # Check
-    assert wgpu.backends.rs._get_wgpu_lib_path() == __file__
+    assert wgpu.backends.rs._get_wgpu_lib_path() == "foo/bar"
 
     # Change it back
     if old_env_var is None:

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -475,11 +475,16 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
         (nx, ny, nz),
     )
     compute_pass = command_encoder.begin_compute_pass()
+    compute_pass.push_debug_group("foo")
+    compute_pass.insert_debug_marker("setting pipeline")
     compute_pass.set_pipeline(compute_pipeline)
+    compute_pass.insert_debug_marker("setting bind group")
     compute_pass.set_bind_group(
         0, bind_group, [], 0, 999999
     )  # last 2 elements not used
+    compute_pass.insert_debug_marker("dispatch!")
     compute_pass.dispatch(nx, ny, nz)
+    compute_pass.pop_debug_group()
     compute_pass.end_pass()
     command_encoder.copy_texture_to_buffer(
         {"texture": texture2, "mip_level": 0, "array_layer": 0, "origin": (0, 0, 0)},

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -76,29 +76,30 @@ def _get_wgpu_lib_path():
     """ Get the path to the wgpu library, taking into account the
     WGPU_LIB_PATH environment variable.
     """
-    paths = []
 
+    # If path is given, use that or fail trying
     override_path = os.getenv("WGPU_LIB_PATH", "").strip()
     if override_path:
-        paths.append(override_path)
+        return override_path
 
-    lib_filename = None
+    # Get lib filename for supported platforms
     if sys.platform.startswith("win"):  # no-cover
         lib_filename = "wgpu_native.dll"
     elif sys.platform.startswith("darwin"):  # no-cover
         lib_filename = "libwgpu_native.dylib"
     elif sys.platform.startswith("linux"):  # no-cover
         lib_filename = "libwgpu_native.so"
-    if lib_filename:
-        # Note that this can be a false positive, e.g. ARM linux.
-        embedded_path = get_resource_filename(lib_filename)
-        paths.append(embedded_path)
-
-    for path in paths:
-        if os.path.isfile(path):
-            return path
     else:  # no-cover
-        raise RuntimeError(f"Could not find WGPU library, checked: {paths}")
+        raise RuntimeError(
+            f"No WGPU library shipped for platform {sys.platform}. Set WGPU_LIB_PATH instead."
+        )
+
+    # Note that this can be a false positive, e.g. ARM linux.
+    embedded_path = get_resource_filename(lib_filename)
+    if not os.path.isfile(embedded_path):  # no-cover
+        raise RuntimeError(f"Could not find WGPU library in {embedded_path}")
+    else:
+        return embedded_path
 
 
 # Configure cffi and load the dynamic library

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1170,6 +1170,11 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
         id = _lib.wgpu_command_encoder_finish(self._internal, struct)
         return base.GPUCommandBuffer(label, id, self)
 
+    # todo: these do not exist yet for command_encoder in wgpu-native
+    # def push_debug_group(self, group_label):
+    # def pop_debug_group(self):
+    # def insert_debug_marker(self, marker_label):
+
 
 class GPUProgrammablePassEncoder(base.GPUProgrammablePassEncoder):
     # wgpu.help('BindGroup', 'Index32', 'Size32', 'Size64', 'programmablepassencodersetbindgroup', dev=True)
@@ -1193,17 +1198,28 @@ class GPUProgrammablePassEncoder(base.GPUProgrammablePassEncoder):
                 self._internal, index, bind_group_id, c_offsets, len(offsets)
             )
 
-    # # wgpu.help('programmablepassencoderpushdebuggroup', dev=True)
-    # def push_debug_group(self, group_label):
-    #     ...
-    #
-    # # wgpu.help('programmablepassencoderpopdebuggroup', dev=True)
-    # def pop_debug_group(self):
-    #     ...
-    #
-    # # wgpu.help('programmablepassencoderinsertdebugmarker', dev=True)
-    # def insert_debug_marker(self, marker_label):
-    #     ...
+    # wgpu.help('programmablepassencoderpushdebuggroup', dev=True)
+    def push_debug_group(self, group_label):
+        c_group_label = ffi.new("char []", group_label.encode())
+        if isinstance(self, GPUComputePassEncoder):
+            _lib.wgpu_compute_pass_push_debug_group(self._internal, c_group_label)
+        else:
+            _lib.wgpu_render_pass_push_debug_group(self._internal, c_group_label)
+
+    # wgpu.help('programmablepassencoderpopdebuggroup', dev=True)
+    def pop_debug_group(self):
+        if isinstance(self, GPUComputePassEncoder):
+            _lib.wgpu_compute_pass_pop_debug_group(self._internal)
+        else:
+            _lib.wgpu_render_pass_pop_debug_group(self._internal)
+
+    # wgpu.help('programmablepassencoderinsertdebugmarker', dev=True)
+    def insert_debug_marker(self, marker_label):
+        c_marker_label = ffi.new("char []", marker_label.encode())
+        if isinstance(self, GPUComputePassEncoder):
+            _lib.wgpu_compute_pass_insert_debug_marker(self._internal, c_marker_label)
+        else:
+            _lib.wgpu_render_pass_insert_debug_marker(self._internal, c_marker_label)
 
 
 class GPUComputePassEncoder(GPUProgrammablePassEncoder):

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -548,7 +548,7 @@ class GPUDevice(GPUObject):
     ):
         """ Create a :class:`GPURenderBundle` object.
 
-        TODO
+        TODO: not yet available in wgpu-native
         """
         raise NotImplementedError()
 
@@ -948,21 +948,21 @@ class GPUCommandEncoder(GPUObject):
     # wgpu.help('commandencoderpushdebuggroup', dev=True)
     # IDL: void pushDebugGroup(DOMString groupLabel);
     def push_debug_group(self, group_label):
-        """ TODO
+        """ TODO: not yet available in wgpu-native
         """
         raise NotImplementedError()
 
     # wgpu.help('commandencoderpopdebuggroup', dev=True)
     # IDL: void popDebugGroup();
     def pop_debug_group(self):
-        """ TODO
+        """ TODO: not yet available in wgpu-native
         """
         raise NotImplementedError()
 
     # wgpu.help('commandencoderinsertdebugmarker', dev=True)
     # IDL: void insertDebugMarker(DOMString markerLabel);
     def insert_debug_marker(self, marker_label):
-        """ TODO
+        """ TODO: not yet available in wgpu-native
         """
         raise NotImplementedError()
 
@@ -1008,21 +1008,21 @@ class GPUProgrammablePassEncoder(GPUObject):
     # wgpu.help('programmablepassencoderpushdebuggroup', dev=True)
     # IDL: void pushDebugGroup(DOMString groupLabel);
     def push_debug_group(self, group_label):
-        """ TODO
+        """ Push a named debug group into the command stream.
         """
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderpopdebuggroup', dev=True)
     # IDL: void popDebugGroup();
     def pop_debug_group(self):
-        """ TODO
+        """ Pop the active debug group.
         """
         raise NotImplementedError()
 
     # wgpu.help('programmablepassencoderinsertdebugmarker', dev=True)
     # IDL: void insertDebugMarker(DOMString markerLabel);
     def insert_debug_marker(self, marker_label):
-        """ TODO
+        """ Insert the given message into the debug message queue.
         """
         raise NotImplementedError()
 
@@ -1230,7 +1230,7 @@ class GPURenderPassEncoder(GPURenderEncoderBase):
     # IDL: void executeBundles(sequence<GPURenderBundle> bundles);
     def execute_bundles(self, bundles):
         """
-        TODO
+        TODO: not yet available in wgpu-native
         """
         raise NotImplementedError()
 
@@ -1244,13 +1244,13 @@ class GPURenderPassEncoder(GPURenderEncoderBase):
 
 class GPURenderBundle(GPUObject):
     """
-    TODO
+    TODO: not yet available in wgpu-native
     """
 
 
 class GPURenderBundleEncoder(GPURenderEncoderBase):
     """
-    TODO
+    TODO: not yet available in wgpu-native
     """
 
     # wgpu.help('RenderBundleDescriptor', 'renderbundleencoderfinish', dev=True)
@@ -1285,7 +1285,7 @@ class GPUQueue(GPUObject):
     # IDL: void copyImageBitmapToTexture( GPUImageBitmapCopyView source, GPUTextureCopyView destination, GPUExtent3D copySize);
     def copy_image_bitmap_to_texture(self, source, destination, copy_size):
         """
-        TODO
+        TODO: not yet available in wgpu-native
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
This adds support for debug groups and markers. I haven't been able to actually see them in RenderDoc, but that is likely because I am missing something else. The C-api of these calls don't leave much room to do something wrong. So we might need to update the guide on debugging when we know a bit more about this.