### PR TITLE
Fix grayscale texture render tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Renderdoc captures
+*.cap
+*.rdc
+
 # C extensions
 *.so
 

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -292,7 +292,6 @@ def test_render_textured_square_r8uint():
     )
 
 
-@mark.skip(reason="This test does not pass yet!")
 def test_render_textured_square_r16sint():
     """ Test a texture with format r16sint. Because e.g. CT data.
     """
@@ -318,7 +317,6 @@ def test_render_textured_square_r16sint():
     )
 
 
-@mark.skip(reason="This test does not pass yet!")
 def test_render_textured_square_r32sint():
     """ Test a texture with format r32sint. Because e.g. CT data.
     """
@@ -344,7 +342,6 @@ def test_render_textured_square_r32sint():
     )
 
 
-@mark.skip(reason="This test does not pass yet!")
 def test_render_textured_square_r32float():
     """ Test a texture with format r32float.
     """

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -297,8 +297,6 @@ def test_render_textured_square_r16sint():
     """ Test a texture with format r16sint. Because e.g. CT data.
     """
 
-    # todo: WHY does this not work???
-
     @python2shader
     def fragment_shader(
         tex: ("texture", 0, "2d r16i"),
@@ -325,8 +323,6 @@ def test_render_textured_square_r32sint():
     """ Test a texture with format r32sint. Because e.g. CT data.
     """
 
-    # todo: WHY does this not work???
-
     @python2shader
     def fragment_shader(
         tex: ("texture", 0, "2d r32i"),
@@ -352,7 +348,6 @@ def test_render_textured_square_r32sint():
 def test_render_textured_square_r32float():
     """ Test a texture with format r32float.
     """
-    # todo: WHY does this not work???
 
     @python2shader
     def fragment_shader(
@@ -408,8 +403,9 @@ def render_textured_square(fragment_shader, texture_format, texture_size, textur
     )
 
     sampler = device.create_sampler(
-        mag_filter="linear", min_filter="linear", compare="never"
+        mag_filter="linear", min_filter="linear", compare=0,
     )
+    # compare 0 means undefined, but there is no wgpu.CompareFunction.undefined !
 
     # Determine texture component type from the format
     if texture_format.endswith(("norm", "float")):
@@ -491,6 +487,6 @@ if __name__ == "__main__":
 
     test_render_textured_square_r8unorm()
     test_render_textured_square_r8uint()
-    # test_render_textured_square_r16sint()  # fails, why?
-    # test_render_textured_square_r32sint()  # fails, why?
-    # test_render_textured_square_r32float()  # fails, why?
+    test_render_textured_square_r16sint()
+    test_render_textured_square_r32sint()
+    test_render_textured_square_r32float()

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -8,7 +8,7 @@ import numpy as np
 import python_shader
 from python_shader import python2shader, f32, vec2, vec4, i32
 import wgpu.backends.rs  # noqa
-from pytest import skip, mark
+from pytest import skip
 from testutils import can_use_wgpu_lib, get_default_device, can_use_vulkan_sdk
 from renderutils import upload_to_texture, render_to_texture, render_to_screen  # noqa
 

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -242,7 +242,7 @@ class GPUDevice(GPUObject):
 
         Arguments:
             label (str): A human readable label. Optional.
-            size (tuple or dict): The texture size with fields (x, y, z).
+            size (tuple or dict): The texture size with fields (width, height, depth).
             mip_level_count (int): The number of mip leveles. Default 1.
             sample_count (int): The number of samples. Default 1.
             dimension (TextureDimension): The dimensionality of the texture.
@@ -280,6 +280,7 @@ class GPUDevice(GPUObject):
             lod_min_clamp (float): The minimum level of detail. Default 0.
             lod_max_clamp (float): The maxium level of detail. Default inf.
             compare (CompareFunction): The sample compare operation for depth textures.
+                For non-depth textures you probably want to set this to zero.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Closes #73 

So the problem appeared to be the `compare` arg in `create_sampler`. It apparently must be set to "undefined". Except ... there is no `wgpu.CompareFunction.undefined`. Fortunately, we can just set it to zero for now.