### PR TITLE
More defaults

### DIFF
--- a/codegen-script.py
+++ b/codegen-script.py
@@ -357,7 +357,7 @@ for fname in ("base.py", "backends/rs.py"):
                 assert argtypes[0].startswith("GPU")
                 arg_struct = ip.structs[argtypes[0][3:]]
                 py_args = [field.py_arg() for field in arg_struct.values()]
-                if py_args[0] == "label: str":
+                if py_args[0].startswith("label: str"):
                     py_args[0] = 'label=""'
                     py_args = ["self", "*"] + py_args
             else:

--- a/codegen-script.py
+++ b/codegen-script.py
@@ -343,9 +343,12 @@ for fname in ("base.py", "backends/rs.py"):
 
             # Get arg names and types
             args = idl_line.split("(", 1)[1].split(")", 1)[0].split(",")
-            argnames = [arg.split("=")[0].split()[-1] for arg in args if arg.strip()]
+            args = [arg.strip() for arg in args if arg.strip()]
+            defaults = [arg.partition("=")[2].strip() for arg in args]
+            argnames = [arg.split("=")[0].split()[-1] for arg in args]
             argnames = [to_python_name(argname) for argname in argnames]
-            argtypes = [arg.split("=")[0].split()[-2] for arg in args if arg.strip()]
+            argnames = [(f"{n}={v}" if v else n) for n, v in zip(argnames, defaults)]
+            argtypes = [arg.split("=")[0].split()[-2] for arg in args]
 
             # Compose searches for help() call
             searches = [func_id_match]

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -99,10 +99,8 @@ def _main(canvas, device):
                     wgpu.BlendFactor.zero,
                     wgpu.BlendOperation.add,
                 ),
-                "write_mask": wgpu.ColorWrite.ALL,
             }
         ],
-        depth_stencil_state=None,
         vertex_state={"index_format": wgpu.IndexFormat.uint32, "vertex_buffers": []},
         sample_count=1,
         sample_mask=0xFFFFFFFF,
@@ -128,8 +126,6 @@ def _main(canvas, device):
                         "store_op": wgpu.StoreOp.store,
                     }
                 ],
-                depth_stencil_attachment=None,
-                occlusion_query_set=None,
             )
 
             render_pass.set_pipeline(render_pipeline)

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -91,7 +91,7 @@ def render_to_texture(
         format=texture_format,
         usage=wgpu.TextureUsage.OUTPUT_ATTACHMENT | wgpu.TextureUsage.COPY_SRC,
     )
-    current_texture_view = texture.create_default_view()
+    current_texture_view = texture.create_view()
 
     # Also a buffer to read the data to CPU
     buffer = device.create_buffer(

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -216,7 +216,6 @@ def _get_draw_function(device, canvas):
                 "write_mask": wgpu.ColorWrite.ALL,
             }
         ],
-        depth_stencil_state=None,
         vertex_state={"index_format": wgpu.IndexFormat.uint32, "vertex_buffers": [],},
         sample_count=1,
         sample_mask=0xFFFFFFFF,
@@ -239,11 +238,7 @@ def _get_draw_function(device, canvas):
                 "load_value": (0, 0, 0, 0),
                 "store_op": wgpu.StoreOp.store,
             }
-            render_pass = command_encoder.begin_render_pass(
-                color_attachments=[ca],
-                depth_stencil_attachment=None,
-                occlusion_query_set=None,
-            )
+            render_pass = command_encoder.begin_render_pass(color_attachments=[ca],)
 
             render_pass.set_pipeline(render_pipeline)
             render_pass.set_bind_group(0, bind_group, [], 0, 999999)

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -407,8 +407,8 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
         format=texture_format,
         usage=wgpu.TextureUsage.STORAGE | wgpu.TextureUsage.COPY_SRC,
     )
-    texture_view1 = texture1.create_default_view()
-    texture_view2 = texture2.create_default_view()
+    texture_view1 = texture1.create_view()
+    texture_view2 = texture2.create_view()
 
     # Determine texture component type from the format
     if texture_format.endswith(("norm", "float")):

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -8,7 +8,7 @@ import numpy as np
 from python_shader import python2shader, f32, vec2, vec4, i32
 from python_shader import RES_INPUT, RES_OUTPUT
 import wgpu.backends.rs  # noqa
-from pytest import skip
+from pytest import skip, raises
 from testutils import can_use_wgpu_lib, get_default_device
 from renderutils import render_to_texture, render_to_screen  # noqa
 
@@ -260,7 +260,7 @@ def test_render_orange_square_vbo():
     # Vertex buffer views
     vbo_view = {
         "array_stride": 4 * 2,
-        "stepmode": "vertex",
+        "step_mode": "vertex",
         "attributes": [
             {"format": wgpu.VertexFormat.float2, "offset": 0, "shader_location": 0,},
         ],
@@ -391,6 +391,12 @@ def test_render_orange_square_viewport():
         bind_group_layouts=[bind_group_layout]
     )
 
+    # Fiddled in a small test to covers the raising of an exception
+    with raises(TypeError):
+        device.create_bind_group(
+            layout=bind_group_layout, entries=[{"resource": device}]
+        )
+
     # Render
     render_args = device, vertex_shader, fragment_shader, pipeline_layout, bind_group
     # render_to_screen(*render_args, renderpass_callback=cb)
@@ -511,7 +517,7 @@ def test_render_orange_square_depth():
     )
 
     depth_stencil_attachment = dict(
-        attachment=depth_stencil_texture.create_default_view(),
+        attachment=depth_stencil_texture.create_view(),
         depth_load_value=0.1,
         depth_store_op=wgpu.StoreOp.store,
         stencil_load_value=wgpu.LoadOp.load,

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -8,7 +8,7 @@ import numpy as np
 import python_shader
 from python_shader import python2shader, f32, vec2, vec4, i32
 import wgpu.backends.rs  # noqa
-from pytest import skip
+from pytest import skip, raises
 from testutils import can_use_wgpu_lib, get_default_device, can_use_vulkan_sdk
 from renderutils import upload_to_texture, render_to_texture, render_to_screen  # noqa
 
@@ -391,18 +391,18 @@ def render_textured_square(fragment_shader, texture_format, texture_size, textur
     )
     upload_to_texture(device, texture, texture_data, nx, ny, nz)
 
-    # texture_view = texture.create_default_view()
+    # texture_view = texture.create_view()
     # or:
     texture_view = texture.create_view(
-        format=texture_format,
-        dimension=wgpu.TextureDimension.d2,
-        aspect=wgpu.TextureAspect.all,
+        format=texture_format, dimension=wgpu.TextureDimension.d2,
     )
+    # But not like these ...
+    with raises(ValueError):
+        texture_view = texture.create_view(dimension=wgpu.TextureDimension.d2,)
+    with raises(ValueError):
+        texture_view = texture.create_view(mip_level_count=1,)
 
-    sampler = device.create_sampler(
-        mag_filter="linear", min_filter="linear", compare=0,
-    )
-    # compare 0 means undefined, but there is no wgpu.CompareFunction.undefined !
+    sampler = device.create_sampler(mag_filter="linear", min_filter="linear")
 
     # Determine texture component type from the format
     if texture_format.endswith(("norm", "float")):

--- a/wgpu/_parsers.py
+++ b/wgpu/_parsers.py
@@ -299,6 +299,10 @@ class IdlParser(BaseParser):
                     arg_type, arg_name = arg.strip().rsplit(" ", 1)
                     if arg_type.startswith("required "):
                         arg_type = arg_type[9:]
+                        # required args should not have a default
+                        assert default is None
+                    else:
+                        default = default or "None"
                     arg_type = typedefs.get(arg_type, arg_type)
                     if arg_type in ["double", "float"]:
                         t = "float"

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1248,7 +1248,7 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
         _lib.wgpu_compute_pass_set_pipeline(self._internal, pipeline_id)
 
     # wgpu.help('Size32', 'computepassencoderdispatch', dev=True)
-    def dispatch(self, x, y, z):
+    def dispatch(self, x, y=1, z=1):
         _lib.wgpu_compute_pass_dispatch(self._internal, x, y, z)
 
     # wgpu.help('Buffer', 'Size64', 'computepassencoderdispatchindirect', dev=True)
@@ -1280,19 +1280,19 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
         _lib.wgpu_render_pass_set_pipeline(self._internal, pipeline_id)
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasesetindexbuffer', dev=True)
-    def set_index_buffer(self, buffer, offset, size):
+    def set_index_buffer(self, buffer, offset=0, size=0):
         _lib.wgpu_render_pass_set_index_buffer(
             self._internal, buffer._internal, int(offset), int(size)
         )
 
     # wgpu.help('Buffer', 'Index32', 'Size64', 'renderencoderbasesetvertexbuffer', dev=True)
-    def set_vertex_buffer(self, slot, buffer, offset, size):
+    def set_vertex_buffer(self, slot, buffer, offset=0, size=0):
         _lib.wgpu_render_pass_set_vertex_buffer(
             self._internal, int(slot), buffer._internal, int(offset), int(size)
         )
 
     # wgpu.help('Size32', 'renderencoderbasedraw', dev=True)
-    def draw(self, vertex_count, instance_count, first_vertex, first_instance):
+    def draw(self, vertex_count, instance_count=1, first_vertex=0, first_instance=0):
         _lib.wgpu_render_pass_draw(
             self._internal, vertex_count, instance_count, first_vertex, first_instance
         )
@@ -1306,7 +1306,12 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
 
     # wgpu.help('SignedOffset32', 'Size32', 'renderencoderbasedrawindexed', dev=True)
     def draw_indexed(
-        self, index_count, instance_count, first_index, base_vertex, first_instance
+        self,
+        index_count,
+        instance_count=1,
+        first_index=0,
+        base_vertex=0,
+        first_instance=0,
     ):
         _lib.wgpu_render_pass_draw_indexed(
             self._internal,

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -39,7 +39,7 @@ from weakref import WeakKeyDictionary
 
 from cffi import FFI, __version_info__ as cffi_version_info
 
-from .. import base
+from .. import base, flags
 from .. import _register_backend
 from .._coreutils import get_resource_filename
 from .._mappings import cstructfield2enum, enummap
@@ -485,7 +485,7 @@ class GPUDevice(base.GPUDevice):
         mipmap_filter: "GPUFilterMode" = "nearest",
         lod_min_clamp: float = 0,
         lod_max_clamp: float = 0xFFFFFFFF,
-        compare: "GPUCompareFunction",
+        compare: "GPUCompareFunction" = None,
     ):
         struct = new_struct(
             "WGPUSamplerDescriptor *",
@@ -496,7 +496,7 @@ class GPUDevice(base.GPUDevice):
             mipmap_filter=mipmap_filter,
             lod_min_clamp=lod_min_clamp,
             lod_max_clamp=lod_max_clamp,
-            compare=compare,
+            compare=0 if compare is None else compare,
         )
 
         id = _lib.wgpu_device_create_sampler(self._internal, struct)
@@ -584,9 +584,7 @@ class GPUDevice(base.GPUDevice):
                     )[0],
                 }
             else:
-                raise TypeError(
-                    f"Unexpected resource type {type(resource)}"
-                )  # no-cover
+                raise TypeError(f"Unexpected resource type {type(resource)}")
             c_resource = new_struct("WGPUBindingResource *", **c_resource_kwargs)
             c_entry = new_struct(
                 "WGPUBindGroupEntry *",
@@ -684,11 +682,11 @@ class GPUDevice(base.GPUDevice):
         label="",
         layout: "GPUPipelineLayout",
         vertex_stage: "GPUProgrammableStageDescriptor",
-        fragment_stage: "GPUProgrammableStageDescriptor",
+        fragment_stage: "GPUProgrammableStageDescriptor" = None,
         primitive_topology: "GPUPrimitiveTopology",
         rasterization_state: "GPURasterizationStateDescriptor" = {},
         color_states: "GPUColorStateDescriptor-list",
-        depth_stencil_state: "GPUDepthStencilStateDescriptor",
+        depth_stencil_state: "GPUDepthStencilStateDescriptor" = None,
         vertex_state: "GPUVertexStateDescriptor" = {},
         sample_count: "GPUSize32" = 1,
         sample_mask: "GPUSampleMask" = 0xFFFFFFFF,
@@ -699,18 +697,20 @@ class GPUDevice(base.GPUDevice):
             module=vertex_stage["module"]._internal,
             entry_point=ffi.new("char []", vertex_stage["entry_point"].encode()),
         )
-        c_fragment_stage = new_struct(
-            "WGPUProgrammableStageDescriptor *",
-            module=fragment_stage["module"]._internal,
-            entry_point=ffi.new("char []", fragment_stage["entry_point"].encode()),
-        )
+        c_fragment_stage = ffi.NULL
+        if fragment_stage is not None:
+            c_fragment_stage = new_struct(
+                "WGPUProgrammableStageDescriptor *",
+                module=fragment_stage["module"]._internal,
+                entry_point=ffi.new("char []", fragment_stage["entry_point"].encode()),
+            )
         c_rasterization_state = new_struct(
             "WGPURasterizationStateDescriptor *",
-            front_face=rasterization_state["front_face"],
-            cull_mode=rasterization_state["cull_mode"],
-            depth_bias=rasterization_state["depth_bias"],
-            depth_bias_slope_scale=rasterization_state["depth_bias_slope_scale"],
-            depth_bias_clamp=rasterization_state["depth_bias_clamp"],
+            front_face=rasterization_state.get("front_face", "ccw"),
+            cull_mode=rasterization_state.get("cull_mode", "none"),
+            depth_bias=rasterization_state.get("depth_bias", 0),
+            depth_bias_slope_scale=rasterization_state.get("depth_bias_slope_scale", 0),
+            depth_bias_clamp=rasterization_state.get("depth_bias_clamp", 0),
         )
         c_color_states_list = []
         for color_state in color_states:
@@ -737,8 +737,8 @@ class GPUDevice(base.GPUDevice):
                 format=color_state["format"],
                 alpha_blend=c_alpha_blend[0],
                 color_blend=c_color_blend[0],
-                write_mask=color_state["write_mask"],
-            )  # enum
+                write_mask=color_state.get("write_mask", 0xF),
+            )
             c_color_states_list.append(c_color_state[0])
         c_color_states_array = ffi.new(
             "WGPUColorStateDescriptor []", c_color_states_list
@@ -746,31 +746,37 @@ class GPUDevice(base.GPUDevice):
         if depth_stencil_state is None:
             c_depth_stencil_state = ffi.NULL
         else:
-            stencil_front = depth_stencil_state["stencil_front"]
+            stencil_front = depth_stencil_state.get("stencil_front", {})
             c_stencil_front = new_struct(
                 "WGPUStencilStateFaceDescriptor *",
-                compare=stencil_front["compare"],
-                fail_op=stencil_front["fail_op"],
-                depth_fail_op=stencil_front["depth_fail_op"],
-                pass_op=stencil_front["pass_op"],
+                compare=stencil_front.get("compare", "always"),
+                fail_op=stencil_front.get("fail_op", "keep"),
+                depth_fail_op=stencil_front.get("depth_fail_op", "keep"),
+                pass_op=stencil_front.get("pass_op", "keep"),
             )
-            stencil_back = depth_stencil_state["stencil_back"]
+            stencil_back = depth_stencil_state.get("stencil_back", {})
             c_stencil_back = new_struct(
                 "WGPUStencilStateFaceDescriptor *",
-                compare=stencil_back["compare"],
-                fail_op=stencil_back["fail_op"],
-                depth_fail_op=stencil_back["depth_fail_op"],
-                pass_op=stencil_back["pass_op"],
+                compare=stencil_back.get("compare", "always"),
+                fail_op=stencil_back.get("fail_op", "keep"),
+                depth_fail_op=stencil_back.get("depth_fail_op", "keep"),
+                pass_op=stencil_back.get("pass_op", "keep"),
             )
             c_depth_stencil_state = new_struct(
                 "WGPUDepthStencilStateDescriptor *",
                 format=depth_stencil_state["format"],
-                depth_write_enabled=bool(depth_stencil_state["depth_write_enabled"]),
-                depth_compare=depth_stencil_state["depth_compare"],
+                depth_write_enabled=bool(
+                    depth_stencil_state.get("depth_write_enabled", False)
+                ),
+                depth_compare=depth_stencil_state.get("depth_compare", "always"),
                 stencil_front=c_stencil_front[0],
                 stencil_back=c_stencil_back[0],
-                stencil_read_mask=depth_stencil_state["stencil_read_mask"],
-                stencil_write_mask=depth_stencil_state["stencil_write_mask"],
+                stencil_read_mask=depth_stencil_state.get(
+                    "stencil_read_mask", 0xFFFFFFFF
+                ),
+                stencil_write_mask=depth_stencil_state.get(
+                    "stencil_write_mask", 0xFFFFFFFF
+                ),
             )
         c_vertex_buffer_descriptors_list = []
         for buffer_des in vertex_state["vertex_buffers"]:
@@ -789,7 +795,7 @@ class GPUDevice(base.GPUDevice):
             c_vertex_buffer_descriptor = new_struct(
                 "WGPUVertexBufferLayoutDescriptor *",
                 array_stride=buffer_des["array_stride"],
-                step_mode=buffer_des["stepmode"],
+                step_mode=buffer_des.get("step_mode", "vertex"),
                 attributes=c_attributes_array,
                 attributes_length=len(c_attributes_list),
             )
@@ -799,7 +805,7 @@ class GPUDevice(base.GPUDevice):
         )
         c_vertex_state = new_struct(
             "WGPUVertexStateDescriptor *",
-            index_format=vertex_state["index_format"],
+            index_format=vertex_state.get("index_format", "uint32"),
             vertex_buffers=c_vertex_buffer_descriptors_array,
             vertex_buffers_length=len(c_vertex_buffer_descriptors_list),
         )
@@ -837,12 +843,13 @@ class GPUDevice(base.GPUDevice):
     #     *,
     #     label="",
     #     color_formats: "GPUTextureFormat-list",
-    #     depth_stencil_format: "GPUTextureFormat",
+    #     depth_stencil_format: "GPUTextureFormat" = None,
     #     sample_count: "GPUSize32" = 1,
     # ):
     #     pass
 
-    def configure_swap_chain(self, canvas, format, usage):
+    def configure_swap_chain(self, canvas, format, usage=None):
+        usage = flags.TextureUsage.OUTPUT_ATTACHMENT if usage is None else usage
         return GPUSwapChain(self, canvas, format, usage)
 
 
@@ -937,32 +944,43 @@ class GPUTexture(base.GPUTexture):
         self,
         *,
         label="",
-        format: "GPUTextureFormat",
-        dimension: "GPUTextureViewDimension",
+        format: "GPUTextureFormat" = None,
+        dimension: "GPUTextureViewDimension" = None,
         aspect: "GPUTextureAspect" = "all",
         base_mip_level: "GPUIntegerCoordinate" = 0,
         mip_level_count: "GPUIntegerCoordinate" = 0,
         base_array_layer: "GPUIntegerCoordinate" = 0,
         array_layer_count: "GPUIntegerCoordinate" = 0,
     ):
+        if format is None or dimension is None:
+            if not (
+                format is None
+                and dimension is None
+                and aspect == "all"
+                and base_mip_level == 0
+                and mip_level_count == 0
+                and base_array_layer == 0
+                and array_layer_count == 0
+            ):
+                raise ValueError(
+                    "In create_view() if any paramter is given, "
+                    + "both format and dimension must be specified."
+                )
+            id = _lib.wgpu_texture_create_view(self._internal, ffi.NULL)
 
-        struct = new_struct(
-            "WGPUTextureViewDescriptor *",
-            format=format,
-            dimension=dimension,
-            aspect=aspect,
-            base_mip_level=base_mip_level,
-            level_count=mip_level_count,
-            base_array_layer=base_array_layer,
-            array_layer_count=array_layer_count,
-        )
+        else:
+            struct = new_struct(
+                "WGPUTextureViewDescriptor *",
+                format=format,
+                dimension=dimension,
+                aspect=aspect,
+                base_mip_level=base_mip_level,
+                level_count=mip_level_count,
+                base_array_layer=base_array_layer,
+                array_layer_count=array_layer_count,
+            )
+            id = _lib.wgpu_texture_create_view(self._internal, struct)
 
-        id = _lib.wgpu_texture_create_view(self._internal, struct)
-        return base.GPUTextureView(label, id, self)
-
-    def create_default_view(self, *, label=""):
-        # This method is available in wgpu-rs, and it's kinda nice :)
-        id = _lib.wgpu_texture_create_view(self._internal, ffi.NULL)
         return base.GPUTextureView(label, id, self)
 
     # wgpu.help('texturedestroy', dev=True)
@@ -988,8 +1006,8 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
         *,
         label="",
         color_attachments: "GPURenderPassColorAttachmentDescriptor-list",
-        depth_stencil_attachment: "GPURenderPassDepthStencilAttachmentDescriptor",
-        occlusion_query_set: "GPUQuerySet",
+        depth_stencil_attachment: "GPURenderPassDepthStencilAttachmentDescriptor" = None,
+        occlusion_query_set: "GPUQuerySet" = None,
     ):
         # Note that occlusion_query_set is ignored because wgpu-native does not have it.
 
@@ -999,7 +1017,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
             texture_view_id = color_attachment["attachment"]._internal
             c_resolve_target = (
                 0
-                if color_attachment["resolve_target"] is None
+                if color_attachment.get("resolve_target", None) is None
                 else color_attachment["resolve_target"]._internal
             )  # this is a TextureViewId or null
             c_load_op, clear_color = _loadop_and_clear_from_value(
@@ -1018,7 +1036,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
                 attachment=texture_view_id,
                 resolve_target=c_resolve_target,
                 load_op=c_load_op,
-                store_op=color_attachment["store_op"],
+                store_op=color_attachment.get("store_op", "store"),
                 clear_color=c_clear_color[0],
             )
             c_color_attachments_list.append(c_attachment[0])
@@ -1078,7 +1096,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
             buffer=source["buffer"]._internal,
             offset=int(source.get("offset", 0)),
             bytes_per_row=int(source["bytes_per_row"]),
-            rows_per_image=int(source["rows_per_image"]),
+            rows_per_image=int(source.get("rows_per_image", 0)),
         )
 
         ori = _tuple_from_tuple_or_dict(destination["origin"], "xyz")
@@ -1118,7 +1136,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder):
             buffer=destination["buffer"]._internal,
             offset=int(destination.get("offset", 0)),
             bytes_per_row=int(destination["bytes_per_row"]),
-            rows_per_image=int(destination["rows_per_image"]),
+            rows_per_image=int(destination.get("rows_per_image", 0)),
         )
 
         size = _tuple_from_tuple_or_dict(copy_size, ("width", "height", "depth"))

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -1078,13 +1078,13 @@ class GPUComputePassEncoder(GPUProgrammablePassEncoder):
 
     # wgpu.help('Size32', 'computepassencoderdispatch', dev=True)
     # IDL: void dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
-    def dispatch(self, x, y, z):
+    def dispatch(self, x, y=1, z=1):
         """ Run the compute shader.
 
         Arguments:
             x (int): The number of cycles in index x.
-            y (int): The number of cycles in index y.
-            z (int): The number of cycles in index z.
+            y (int): The number of cycles in index y. Default 1.
+            z (int): The number of cycles in index z. Default 1.
         """
         raise NotImplementedError()
 
@@ -1124,39 +1124,39 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
 
     # wgpu.help('Buffer', 'Size64', 'renderencoderbasesetindexbuffer', dev=True)
     # IDL: void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    def set_index_buffer(self, buffer, offset, size):
+    def set_index_buffer(self, buffer, offset=0, size=0):
         """ Set the index buffer for this render pass.
 
         Arguments:
             buffer (GPUBuffer): The buffer that contains the indices.
-            offset (int): The byte offset in the buffer..
-            size (int): The number of bytes to use.
+            offset (int): The byte offset in the buffer. Default 0.
+            size (int): The number of bytes to use. Default 0.
         """
         raise NotImplementedError()
 
     # wgpu.help('Buffer', 'Index32', 'Size64', 'renderencoderbasesetvertexbuffer', dev=True)
     # IDL: void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    def set_vertex_buffer(self, slot, buffer, offset, size):
+    def set_vertex_buffer(self, slot, buffer, offset=0, size=0):
         """ Associate a vertex buffer with a bind slot.
 
         Arguments:
             slot (int): The binding slot for the vertex buffer.
             buffer (GPUBuffer): The buffer that contains the vertex data.
-            offset (int): The byte offset in the buffer.
-            size (int): The number of bytes to use.
+            offset (int): The byte offset in the buffer. Default 0.
+            size (int): The number of bytes to use. Default 0.
         """
         raise NotImplementedError()
 
     # wgpu.help('Size32', 'renderencoderbasedraw', dev=True)
     # IDL: void draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,  optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
-    def draw(self, vertex_count, instance_count, first_vertex, first_instance):
+    def draw(self, vertex_count, instance_count=1, first_vertex=0, first_instance=0):
         """ Run the render pipeline without an index buffer.
 
         Arguments:
             vertex_count (int): The number of vertices to draw.
-            instance_count (int):  The number of instances to draw.
-            first_vertex (int): The vertex offset.
-            first_instance (int):  The instance offset.
+            instance_count (int):  The number of instances to draw. Default 1.
+            first_vertex (int): The vertex offset. Default 0.
+            first_instance (int):  The instance offset. Default 0.
         """
         raise NotImplementedError()
 
@@ -1174,16 +1174,21 @@ class GPURenderEncoderBase(GPUProgrammablePassEncoder):
     # wgpu.help('SignedOffset32', 'Size32', 'renderencoderbasedrawindexed', dev=True)
     # IDL: void drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,  optional GPUSize32 firstIndex = 0,  optional GPUSignedOffset32 baseVertex = 0,  optional GPUSize32 firstInstance = 0);
     def draw_indexed(
-        self, index_count, instance_count, first_index, base_vertex, first_instance
+        self,
+        index_count,
+        instance_count=1,
+        first_index=0,
+        base_vertex=0,
+        first_instance=0,
     ):
         """ Run the render pipeline using an index buffer.
 
         Arguments:
             index_count (int): The number of indices to draw.
-            instance_count (int): The number of instances to draw.
-            first_index (int):  The index offset.
-            base_vertex (int):  A number added to each index in the index buffer.
-            first_instance (int): The instance offset.
+            instance_count (int): The number of instances to draw. Default 1.
+            first_index (int):  The index offset. Default 0.
+            base_vertex (int):  A number added to each index in the index buffer. Default 0.
+            first_instance (int): The instance offset. Default 0.
         """
         raise NotImplementedError()
 

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -84,8 +84,8 @@ class GPUAdapter:  # Not a GPUObject
 
         Arguments:
             label (str): A human readable label. Optional.
-            extensions (list of str): the extensions that you need.
-            limits (dict): the various limits that you need.
+            extensions (list of str): the extensions that you need. Default [].
+            limits (dict): the various limits that you need. Default {}.
         """
         raise NotImplementedError()
 
@@ -245,7 +245,7 @@ class GPUDevice(GPUObject):
             size (tuple or dict): The texture size with fields (width, height, depth).
             mip_level_count (int): The number of mip leveles. Default 1.
             sample_count (int): The number of samples. Default 1.
-            dimension (TextureDimension): The dimensionality of the texture.
+            dimension (TextureDimension): The dimensionality of the texture. Default 2d.
             format (TextureFormat): What channels it stores and how.
             usage (TextureUsageFlags): The ways in which the texture will be used.
         """
@@ -265,22 +265,25 @@ class GPUDevice(GPUObject):
         mipmap_filter: "GPUFilterMode" = "nearest",
         lod_min_clamp: float = 0,
         lod_max_clamp: float = 0xFFFFFFFF,
-        compare: "GPUCompareFunction",
+        compare: "GPUCompareFunction" = None,
     ):
         """ Create a :class:`GPUSampler` object. Samplers specify how a texture is sampled.
 
         Arguments:
             label (str): A human readable label. Optional.
             address_mode_u (AddressMode): What happens when sampling beyond the x edge.
+                Default "clamp-to-edge".
             address_mode_v (AddressMode): What happens when sampling beyond the y edge.
+                Default "clamp-to-edge".
             address_mode_w (AddressMode): What happens when sampling beyond the z edge.
+                Default "clamp-to-edge".
             mag_filter (FilterMode): Interpolation when zoomed in. Default 'nearest'.
             min_filter (FilterMode): Interpolation when zoomed out. Default 'nearest'.
             mipmap_filter: (FilterMode): Interpolation between mip levels. Default 'nearest'.
             lod_min_clamp (float): The minimum level of detail. Default 0.
             lod_max_clamp (float): The maxium level of detail. Default inf.
             compare (CompareFunction): The sample compare operation for depth textures.
-                For non-depth textures you probably want to set this to zero.
+                Only specify this for depth textures. Default None.
         """
         raise NotImplementedError()
 
@@ -309,14 +312,29 @@ class GPUDevice(GPUObject):
                 "type": wgpu.BindingType.storage_buffer,
                 "has_dynamic_offset": False,  # optional
             },
-            # Texture
+            # Sampler
             {
                 "binding": 1,
+                "visibility": wgpu.ShaderStage.COMPUTE,
+                "type": wgpu.BindingType.sampler,
+            },
+            # Sampled texture
+            {
+                "binding": 2,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
                 "type": wgpu.BindingType.sampled_texture,
                 "view_dimension": wgpu.TextureViewDimension.d2,
                 "texture_component_type": wgpu.TextureComponentType.float,
-                "storage_texture_format": wgpu.TextureFormat.rgba8unorm,
+                "multisampled": False,  # optional
+            },
+            # Storage texture
+            {
+                "binding": 2,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "type": wgpu.BindingType.readonly_storage_texture,
+                "view_dimension": wgpu.TextureViewDimension.d2,
+                "texture_component_type": wgpu.TextureComponentType.float,
+                "storage_texture_format": wgpu.TextureFormat.r32float,
                 "multisampled": False,  # optional
             },
 
@@ -428,11 +446,11 @@ class GPUDevice(GPUObject):
         label="",
         layout: "GPUPipelineLayout",
         vertex_stage: "GPUProgrammableStageDescriptor",
-        fragment_stage: "GPUProgrammableStageDescriptor",
+        fragment_stage: "GPUProgrammableStageDescriptor" = None,
         primitive_topology: "GPUPrimitiveTopology",
         rasterization_state: "GPURasterizationStateDescriptor" = {},
         color_states: "GPUColorStateDescriptor-list",
-        depth_stencil_state: "GPUDepthStencilStateDescriptor",
+        depth_stencil_state: "GPUDepthStencilStateDescriptor" = None,
         vertex_state: "GPUVertexStateDescriptor" = {},
         sample_count: "GPUSize32" = 1,
         sample_mask: "GPUSampleMask" = 0xFFFFFFFF,
@@ -444,26 +462,29 @@ class GPUDevice(GPUObject):
             label (str): A human readable label. Optional.
             layout (GPUPipelineLayout): A layout created with ``create_pipeline_layout()``.
             vertex_stage (dict): E.g. ``{"module": shader_module, entry_point="main"}``
-            fragment_stage (dict): E.g. ``{"module": shader_module, entry_point="main"}``
+            fragment_stage (dict): E.g. ``{"module": shader_module, entry_point="main"}``. Default None.
             primitive_topology (PrimitiveTopology): The topology, e.g. triangles or lines.
-            rasterization_state (dict): Specify rasterization rules. See below.
+            rasterization_state (dict): Specify rasterization rules. See below. Default None.
             color_states (list of dict): Specify color blending rules. See below.
-            depth_stencil_state (dict): Specify texture for depth and stencil. Can be None. See below.
+            depth_stencil_state (dict): Specify texture for depth and stencil. See below. Default None.
             vertex_state (dict): Specify index and vertex buffer info. See below.
-            sample_count (int): Set higher than one for subsampling.
-            sample_mask (int): Sample bitmask.
-            alpha_to_coverage_enabled (bool): Wheher to anable alpha coverage.
+            sample_count (int): Set higher than one for subsampling. Default 1.
+            sample_mask (int): Sample bitmask. Default all ones.
+            alpha_to_coverage_enabled (bool): Wheher to anable alpha coverage. Default False.
+
+        In the example dicts below, the values that are marked as optional,
+        the shown value is the default.
 
         Example rasterization state dict:
 
         .. code-block:: py
 
             {
-                "front_face": wgpu.FrontFace.ccw,
-                "cull_mode": wgpu.CullMode.none,
-                "depth_bias": 0,
-                "depth_bias_slope_scale": 0.0,
-                "depth_bias_clamp": 0.0
+                "front_face": wgpu.FrontFace.ccw,  # optional
+                "cull_mode": wgpu.CullMode.none,  # optional
+                "depth_bias": 0,  # optional
+                "depth_bias_slope_scale": 0.0,  # optional
+                "depth_bias_clamp": 0.0  # optional
             }
 
         Example color state dict:
@@ -472,9 +493,17 @@ class GPUDevice(GPUObject):
 
             {
                 "format": wgpu.TextureFormat.bgra8unorm_srgb,
-                "alpha_blend": (wgpu.BlendFactor.One, wgpu.BlendFactor.zero, wgpu.BlendOperation.add),
-                "colorBlend": (wgpu.BlendFactor.One, wgpu.BlendFactor.zero, wgpu.BlendOperation.add),
-                "writeMask": wgpu.ColorWrite.ALL
+                "alpha_blend": (
+                    wgpu.BlendFactor.One,
+                    wgpu.BlendFactor.zero,
+                    wgpu.BlendOperation.add,
+                ),
+                "color_blend": (
+                    wgpu.BlendFactor.One,
+                    wgpu.BlendFactor.zero,
+                    gpu.BlendOperation.add,
+                ),
+                "write_mask": wgpu.ColorWrite.ALL  # optional
             }
 
         Example depth-stencil state dict:
@@ -483,22 +512,22 @@ class GPUDevice(GPUObject):
 
             {
                 "format": wgpu.TextureFormat.depth24plus_stencil8,
-                "depth_write_enabled": True,
-                "depth_compare": wgpu.CompareFunction.less_equal,
-                "stencil_front": {
+                "depth_write_enabled": False,  # optional
+                "depth_compare": wgpu.CompareFunction.always,  # optional
+                "stencil_front": {  # optional
                     "compare": wgpu.CompareFunction.equal,
                     "fail_op": wgpu.StencilOperation.keep,
                     "depth_fail_op": wgpu.StencilOperation.keep,
                     "pass_op": wgpu.StencilOperation.keep,
                 },
-                "stencil_back": {
+                "stencil_back": {  # optional
                     "compare": wgpu.CompareFunction.equal,
                     "fail_op": wgpu.StencilOperation.keep,
                     "depth_fail_op": wgpu.StencilOperation.keep,
                     "pass_op": wgpu.StencilOperation.keep,
                 },
-                "stencil_read_mask": 0,
-                "stencil_write_mask": 0,
+                "stencil_read_mask": 0xFFFFFFFF,  # optional
+                "stencil_write_mask": 0xFFFFFFFF,  # optional
             }
 
         Example vertex state dict:
@@ -510,7 +539,7 @@ class GPUDevice(GPUObject):
                 "vertexBuffers": [
                     {
                         "array_stride": 8,
-                        "stepmode": "vertex",
+                        "step_mode": wgpu.InputStepMode.vertex,  # optional
                         "attributes": [
                             {
                                 "format": wgpu.VertexFormat.float2,
@@ -545,7 +574,7 @@ class GPUDevice(GPUObject):
         *,
         label="",
         color_formats: "GPUTextureFormat-list",
-        depth_stencil_format: "GPUTextureFormat",
+        depth_stencil_format: "GPUTextureFormat" = None,
         sample_count: "GPUSize32" = 1,
     ):
         """ Create a :class:`GPURenderBundle` object.
@@ -554,7 +583,7 @@ class GPUDevice(GPUObject):
         """
         raise NotImplementedError()
 
-    def configure_swap_chain(self, canvas, format, usage):
+    def configure_swap_chain(self, canvas, format, usage=None):
         """ Get a :class:`GPUSwapChain` object for the given canvas.
         In the WebGPU spec this is a method of the canvas. In wgpu-py
         it's a method of the device.
@@ -562,7 +591,7 @@ class GPUDevice(GPUObject):
         Parameters:
             canvas (WgpuCanvasInterface): An object implementing the canvas interface.
             format (TextureFormat): The texture format, e.g. "bgra8unorm-srgb".
-            usage (TextureUsage): Probably ``wgpu.TextureUsage.OUTPUT_ATTACHMENT``.
+            usage (TextureUsage): Default ``TextureUsage.OUTPUT_ATTACHMENT``.
         """
         # This was made a method of device to help decouple the canvas
         # implementation from the wgpu API.
@@ -703,8 +732,8 @@ class GPUTexture(GPUObject):
         self,
         *,
         label="",
-        format: "GPUTextureFormat",
-        dimension: "GPUTextureViewDimension",
+        format: "GPUTextureFormat" = None,
+        dimension: "GPUTextureViewDimension" = None,
         aspect: "GPUTextureAspect" = "all",
         base_mip_level: "GPUIntegerCoordinate" = 0,
         mip_level_count: "GPUIntegerCoordinate" = 0,
@@ -713,24 +742,19 @@ class GPUTexture(GPUObject):
     ):
         """ Create a :class:`GPUTextureView` object.
 
+        If no aguments are given, a default view is given, with the
+        same format and dimension as the texture.
+
         Arguments:
             label (str): A human readable label. Optional.
             format (TextureFormat): What channels it stores and how.
             dimension (TextureViewDimension): The dimensionality of the texture view.
             aspect (TextureAspect): Whether this view is used for depth, stencil, or all.
-            base_mip_level (int): The starting mip level.
-            mip_level_count (int): The number of mip levels.
-            base_array_layer (int): The starting array layer.
-            array_layer_count (int): The number of array layers.
-        """
-        raise NotImplementedError()
-
-    def create_default_view(self, *, label=""):
-        """ Get the default view on this texture. This method is not part of
-        the WebGPU API, but we (currently) provide it because it's so useful.
-
-        Parameters:
-            label (str): A human readable label. Optional.
+                Default all.
+            base_mip_level (int): The starting mip level. Default 0.
+            mip_level_count (int): The number of mip levels. Default 0.
+            base_array_layer (int): The starting array layer. Default 0.
+            array_layer_count (int): The number of array layers. Default 0.
         """
         raise NotImplementedError()
 
@@ -748,8 +772,7 @@ class GPUTextureView(GPUObject):
     """
     A texture view represents a way to represent a :class:`GPUTexture`.
 
-    Create a texture view using :func:`GPUTexture.create_view` or
-    :func:`GPUTexture.create_default_view`.
+    Create a texture view using :func:`GPUTexture.create_view`.
     """
 
 
@@ -865,8 +888,8 @@ class GPUCommandEncoder(GPUObject):
         *,
         label="",
         color_attachments: "GPURenderPassColorAttachmentDescriptor-list",
-        depth_stencil_attachment: "GPURenderPassDepthStencilAttachmentDescriptor",
-        occlusion_query_set: "GPUQuerySet",
+        depth_stencil_attachment: "GPURenderPassDepthStencilAttachmentDescriptor" = None,
+        occlusion_query_set: "GPUQuerySet" = None,
     ):
         """ Record the beginning of a render pass. Returns a
         :class:`GPURenderPassEncoder` object.
@@ -874,17 +897,18 @@ class GPUCommandEncoder(GPUObject):
         Arguments:
             label (str): A human readable label. Optional.
             color_attachements (list of dict): List of color attachement dicts. See below.
-            depth_stencil_attachment (dict): A depth stencil attachement dict. See below.
-            occlusion_query_set: IGNORED, NOT IMPLEMENTED in wgpu-native
+            depth_stencil_attachment (dict): A depth stencil attachement dict. See below. Default None.
+            occlusion_query_set: Default None. TODO NOT IMPLEMENTED in wgpu-native.
 
         Example color attachement:
 
         .. code-block:: py
 
             {
-                "resolve_target": None,
+                "attachement": texture_view,
+                "resolve_target": None,  # optional
                 "load_value": (0, 0, 0, 0),  # LoadOp.load or a color
-                "store_op": wgpu.StoreOp.store,
+                "store_op": wgpu.StoreOp.store,  # optional
             }
 
         Example depth stencil attachement:

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -93,7 +93,6 @@
 *  Not implemented: void destroy(); (querysetdestroy)
 *  Found unknown function configure_swap_chain (deviceconfigureswapchain)
 *  Found unknown function get_swap_chain_preferred_format (devicegetswapchainpreferredformat)
-*  Found unknown function create_default_view (texturecreatedefaultview)
 *  Injected IDL lines into base.py
 
 ### Check functions in backends/rs.py
@@ -116,5 +115,4 @@
 *  Not implemented: void destroy(); (querysetdestroy)
 *  Not implemented: GPUTexture getCurrentTexture(); (swapchaingetcurrenttexture)
 *  Found unknown function configure_swap_chain (deviceconfigureswapchain)
-*  Found unknown function create_default_view (texturecreatedefaultview)
 *  Injected IDL lines into backends/rs.py


### PR DESCRIPTION
Closes #90 

* Changed the parsing of IDL to take care of default values. 
* Document the default values in `base.py`
* Implement the default values of sub-arguments (dicts) in `rs.py`
* The most notable api change is that we no longer have `texture.create_default_view()`. Instead you call `texture.create_view()` without arguments.