### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This code is distributed under the 2-clause BSD license.
 
 * Clone the repo.
 * Install devtools using `pip install -r dev-requirements.txt` (you can replace `pip` with `pipenv` to install to a virtualenv).
-* Install wgpu-py in editable mode by running `python setup.py develop`, this will also install our only runtime dependency `cffi`
+* Install wgpu-py in editable mode by running `pip install -e .`, this will also install our only runtime dependency `cffi`
 * Run `python download-wgpu-native.py` to download the upstream wgpu-native binaries.
   * Or alternatively point the `WGPU_LIB_PATH` environment variable to a custom build.
 * Use `black .` to apply autoformatting.


### PR DESCRIPTION
Recently we figured out that `python setup py develop` doesn't properly update the python environment, because it doesn't involve `pip`!