### PR TITLE
Support turning on wgpu validation flag

### DIFF
--- a/wgpu/backends/wgpu_native/_helpers.py
+++ b/wgpu/backends/wgpu_native/_helpers.py
@@ -88,6 +88,10 @@ def get_wgpu_instance():
     if _the_instance is None:
         # H: nextInChain: WGPUChainedStruct *
         struct = ffi.new("WGPUInstanceDescriptor *")
+        extras = ffi.new("WGPUInstanceExtras *")
+        extras.flags = lib.WGPUInstanceFlag_Validation  # | lib.WGPUInstanceFlag_Debug
+        extras.chain.sType = lib.WGPUSType_InstanceExtras
+        struct.nextInChain = ffi.cast("WGPUChainedStruct * ", extras)
         _the_instance = lib.wgpuCreateInstance(struct)
     return _the_instance
 


### PR DESCRIPTION
* [x] Turn on the flag.
* [ ] Make it conditional (maybe en env var?)
* [ ] Figure out what it does 😆 
    * I *think* this turns on the Vulkan validation layers, if you have the Lunar SDK installed.
    * On MacOS with Metal I see no difference in the (debug) logs.
    * ... I'm having trouble running on Vulkan on MacOS.
    * Windows: With the Vulkan Configurator on, the validation layers are active, and it prints (to sys stdout / file 0) that the validation layer is active ... but it also does this without the change in this pr.

https://github.com/gfx-rs/wgpu-native/issues/327