### PR TITLE
Switch to trusted publishing for PyPI publish in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,6 +101,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-wheels, test-wheels]
     if: success() && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/wgpu
+    permissions:
+      contents: write
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -134,5 +140,4 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+        print-hash: true


### PR DESCRIPTION
You'll need to create a new GitHub environment called `pypi` ([GitHub docs](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#creating-an-environment)), and add it to PyPI ([PyPI docs](https://docs.pypi.org/trusted-publishers/adding-a-publisher/#github-actions)).

Also enables computing and displaying published files' hashes.

Resolves #734

Related: pygfx/pygfx#1192