### PR TITLE
Fix that memory for struct data was released before wgpu-native consumed it

### DIFF
--- a/wgpu/backends/wgpu_native/_helpers.py
+++ b/wgpu/backends/wgpu_native/_helpers.py
@@ -95,11 +95,13 @@ def get_wgpu_instance(extras=None):
         raise RuntimeError(
             "Instance already exists. Please call `set_instance_extras` before the instance is created (calls to `request_adapter` or `enumerate_adapters`)"
         )
+
     if _the_instance is None:
         # H: nextInChain: WGPUChainedStruct *
         struct = ffi.new("WGPUInstanceDescriptor *")
         if extras is not None:
-            struct.nextInChain = ffi.cast("WGPUChainedStruct *", extras)
+            c_instance_next_in_chain = ffi.cast("WGPUChainedStruct *", extras)
+            struct.nextInChain = c_instance_next_in_chain
         _the_instance = lib.wgpuCreateInstance(struct)
     return _the_instance
 


### PR DESCRIPTION
Fixes #763 (very probably)

I checked every case of `ffi.cast()`, and refactored each instance where we use `nextInChain` to use the same pattern.

The actual problem in #763 is fixed by letting the function `_create_render_pipeline_descriptor()` also return a list of objects, so that their lifetime is bound to the scope of the caller instead of the scope of the function.