### PR TITLE
Fix error when the window is minimized

### DIFF
--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -273,8 +273,8 @@ class GPUCanvasContext:
         The application must call this to keep the context informed about
         the window/framebuffer size.
         """
-        if width <= 0 or height <= 0:
-            raise ValueError("Physical size values must be positive.")
+        if width < 0 or height < 0:
+            raise ValueError("Physical size values must be non-negative.")
         self._physical_size = int(width), int(height)
         self._has_new_size = True
 


### PR DESCRIPTION
When the window is minimized, the application crashes.
```
Traceback (most recent call last):
  File "F:\rendercanvas\rendercanvas\_coreutils.py", line 50, in log_exception
    yield
  File "F:\rendercanvas\rendercanvas\_loop.py", line 241, in wrapper
    await async_func(*args)
  File "F:\rendercanvas\rendercanvas\_scheduler.py", line 164, in __scheduler_task
    canvas._process_events()
  File "F:\rendercanvas\rendercanvas\base.py", line 390, in _process_events
    self.__maybe_emit_resize_event()
  File "F:\rendercanvas\rendercanvas\base.py", line 361, in __maybe_emit_resize_event
    self._canvas_context._rc_set_size_dict(self._size_info)
  File "F:\rendercanvas\rendercanvas\contexts\basecontext.py", line 54, in _rc_set_size_dict
    self._wgpu_context.set_physical_size(*size_info["physical_size"])
  File "F:\wgpu-py\wgpu\_classes.py", line 277, in set_physical_size
    raise ValueError("Physical size values must be positive.")
ValueError: Physical size values must be positive.
```

I think `physical_size` can be (0, 0).