### PR TITLE
fix GPUPromise type annotation

### DIFF
--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -624,6 +624,10 @@ class BackendApiPatcher(AbstractApiPatcher):
     def get_class_def(self, classname):
         line, _ = self.classes[classname]
 
+        if line.startswith("class GPUPromise"):
+            # otherwise the else block below strips the typevar.
+            return "class GPUPromise(classes.GPUPromise[AwaitedType]):"
+
         if "):" not in line:
             return line.replace(":", f"(classes.{classname}):")
         else:

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -15,7 +15,7 @@ import logging
 import itertools
 from typing import Sequence
 
-from ._async import GPUPromise as BaseGPUPromise
+from ._async import GPUPromise as BaseGPUPromise, AwaitedType
 from ._coreutils import ApiDiff, str_flag_to_int, ArrayLike, CanvasLike
 from ._diagnostics import diagnostics, texture_format_to_bpp
 from . import flags, enums, structs
@@ -224,7 +224,7 @@ gpu = GPU()
 
 
 @apidiff.add("Added for async support")
-class GPUPromise(BaseGPUPromise):
+class GPUPromise(BaseGPUPromise[AwaitedType]):
     pass
 
 

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -24,6 +24,7 @@ from weakref import WeakKeyDictionary
 from typing import NoReturn, Sequence
 
 from ..._coreutils import str_flag_to_int, ArrayLike, CanvasLike
+from ..._async import AwaitedType
 from ... import classes, flags, enums, structs
 
 from ._ffi import ffi, lib
@@ -684,7 +685,7 @@ class GPU(classes.GPU):
 gpu = GPU()
 
 
-class GPUPromise(classes.GPUPromise):
+class GPUPromise(classes.GPUPromise[AwaitedType]):
     def _sync_wait(self):
         # In the wgpu-native backend, we do the polling in a per-device thread.
         # The base class already sets a threading.Event, we can just use that here.


### PR DESCRIPTION
Little typing improvement that hands down the generic `AwaitedType` for `GPUPromise` to the subclasses. 

I don't like that there is an edge case but couldn't find anything easier to read that handles `BaseGPUPromise[AwaitedType]` in that function with the existing logic.

before:
<img width="681" height="374" alt="image" src="https://github.com/user-attachments/assets/3abe1ede-ab5d-49ea-a3dd-a174823ceb53" />


after: 
<img width="704" height="375" alt="image" src="https://github.com/user-attachments/assets/0d1d49f4-7913-4cea-a25a-d9055ab549bc" />

LSP is way happier this way and shows fewer white method names and red squiggles