### PR TITLE
Require python 3.11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Test Linux py310
-            os: ubuntu-latest
-            pyversion: '3.10'
           - name: Test Linux py311
             os: ubuntu-latest
             pyversion: '3.11'

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -7,7 +7,7 @@ Install with pip
 ----------------
 
 You can install ``wgpu-py`` with your favourite package manager (we use ``pip`` in the example commands below).
-Python 3.10 or higher is required. Pypy is supported.
+Python 3.11 or higher is required. Pypy is supported.
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Almar Klein" }, { name = "Korijn van Golen" }]
 keywords = ["webgpu", "wgpu", "vulkan", "metal", "DX12", "opengl"]
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 dependencies = [
     "cffi>=1.15.0",
     "rubicon-objc>=0.4.1; sys_platform == 'darwin'",


### PR DESCRIPTION
Python 3.10 is EOL in 4 weeks (see https://endoflife.date/python).

Our py310 build fails lately. Since the fail is very specific for 3.10, I'm going to assume it's confined to that version of Python. Instead of spending a lot of time why the tests abort, we can drop support for 3.10 now 🤷 