### PR TITLE
Bump version

### DIFF
--- a/wgpu/_version.py
+++ b/wgpu/_version.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 # This is the base version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "0.31.0"
+__version__ = "0.31.1"
 
 # Set this to your library name
 project_name = "wgpu"


### PR DESCRIPTION
New release for all changes since last release, so that we have a dedicated release for the wgpu-native update.